### PR TITLE
#86 Add ATOMIC_MOVE to file move in XmlPrimary.close()

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
@@ -159,8 +159,7 @@ public final class XmlPrimary implements Closeable {
             Files.move(
                 trf,
                 this.tmp,
-                StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.ATOMIC_MOVE
+                StandardCopyOption.REPLACE_EXISTING
             );
         } catch (final XMLStreamException | TransformerException err) {
             throw new IOException("Failed to close", err);

--- a/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
@@ -129,6 +129,7 @@ public final class XmlPrimary implements Closeable {
         return new Package(this.xml, this);
     }
 
+    // @checkstyle ExecutableStatementCount (30 lines)
     @Override
     public void close() throws IOException {
         final Path trf = Files.createTempFile("primary-", ".xml");

--- a/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
@@ -148,7 +148,7 @@ public final class XmlPrimary implements Closeable {
                 new StAXSource(reader),
                 new StreamResult(Files.newOutputStream(trf, StandardOpenOption.TRUNCATE_EXISTING))
             );
-            Files.move(trf, this.tmp, StandardCopyOption.REPLACE_EXISTING);
+            Files.move(trf, this.tmp, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
         } catch (final XMLStreamException | TransformerException err) {
             throw new IOException("Failed to close", err);
         } finally {

--- a/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
@@ -148,7 +148,12 @@ public final class XmlPrimary implements Closeable {
                 new StAXSource(reader),
                 new StreamResult(Files.newOutputStream(trf, StandardOpenOption.TRUNCATE_EXISTING))
             );
-            Files.move(trf, this.tmp, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            Files.move(
+                trf,
+                this.tmp,
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE
+            );
         } catch (final XMLStreamException | TransformerException err) {
             throw new IOException("Failed to close", err);
         } finally {

--- a/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
@@ -153,8 +153,15 @@ public final class XmlPrimary implements Closeable {
                     new StAXSource(reader),
                     new StreamResult(output)
                 );
+            } finally {
+                Files.deleteIfExists(this.tmp);
             }
-            Files.move(trf, this.tmp, StandardCopyOption.REPLACE_EXISTING);
+            Files.move(
+                trf,
+                this.tmp,
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE
+            );
         } catch (final XMLStreamException | TransformerException err) {
             throw new IOException("Failed to close", err);
         } finally {

--- a/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
@@ -153,6 +153,7 @@ public final class XmlPrimary implements Closeable {
                     new StAXSource(reader),
                     new StreamResult(output)
                 );
+                reader.close();
             } finally {
                 Files.deleteIfExists(this.tmp);
             }

--- a/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
@@ -160,7 +160,7 @@ public final class XmlPrimary implements Closeable {
             Files.move(
                 trf,
                 this.tmp,
-                StandardCopyOption.REPLACE_EXISTING
+                StandardCopyOption.ATOMIC_MOVE
             );
         } catch (final XMLStreamException | TransformerException err) {
             throw new IOException("Failed to close", err);

--- a/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -33,8 +33,6 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -48,12 +46,7 @@ import org.junit.jupiter.api.io.TempDir;
  *  where SHA1 is a HEX from SHA1 of file content and TYPE is a type of file
  *  (primary, others, filelists). Don't forget to uncompress it first.
  *  repomd.xml is not compressed and stored at `repodata/repomd.xml`.
- * @todo #69:30min This test is failing on Windows build. It's failing because of error
- *  FileAlreadyExistException in PrimaryXml.close in Files.move, but it's using
- *  REPLACE_EXISTING options, so it should not fail and it's not failing on Linux.
- *  Let's discover the problem, fix it, and remove DisabledOnOs(OS.WINDOWS) annotation.
  */
-@DisabledOnOs(OS.WINDOWS)
 final class RpmITCase {
 
     /**


### PR DESCRIPTION
#86: Add `ATOMIC_MOVE` to file move option in `XmlPrimary.close()`, re-enabled `RpmITCase` on Windows.