### PR TITLE
For #82: xmlothers changelog refinement

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlOthers.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlOthers.java
@@ -166,15 +166,15 @@ public final class XmlOthers implements Closeable {
         /**
          * Adds changelog tag to others.xml file.
          * @param author Changelog author
-         * @param epoch Epoch seconds
+         * @param date Epoch seconds
          * @param content Changelog content
          * @return Self
          * @throws XMLStreamException On error
          */
-        public Package changelog(final String author, final int epoch, final String content)
+        public Package changelog(final String author, final int date, final String content)
             throws XMLStreamException {
             this.xml.writeStartElement("changelog");
-            this.xml.writeAttribute("epoch", String.valueOf(epoch));
+            this.xml.writeAttribute("date", String.valueOf(date));
             this.xml.writeAttribute("author", String.valueOf(author));
             this.xml.writeCharacters(content);
             this.xml.writeEndElement();

--- a/src/main/java/com/artipie/rpm/meta/XmlOthers.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlOthers.java
@@ -26,6 +26,7 @@ package com.artipie.rpm.meta;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import javax.xml.stream.XMLStreamException;
 
 /**
@@ -144,13 +145,17 @@ public final class XmlOthers implements Closeable {
 
         /**
          * Add changelog.
+         * @param changelogs List of changelog items
          * @return Self
          * @throws XMLStreamException On error
-         * @todo #69:30min Implement changelog method. It's not clear how exaclty it should
-         *  be extracted from package headers. Check example RPM packages in test bin resources
-         *  and `other.xml` file for this file in test resources.
+         * @todo #82:30min Continue changelog implementation.
+         *  Changelog info is composed of a sequence of entries (as seen in
+         *  https://rpm-packaging-guide.github.io/#packaging-software ,changelog
+         *  section). This information will be extracted from package headers
+         *  and sent here to be parsed and added to the others.xml file. After
+         *  implementing this enable test on XmlOthersTest.
          */
-        public Package changelog()
+        public Package changelog(final List<String> changelogs)
             throws XMLStreamException {
             this.xml.writeStartElement("changelog");
             this.xml.writeCharacters("NOT_IMPLEMENTED");
@@ -168,7 +173,12 @@ public final class XmlOthers implements Closeable {
          */
         public Package changelog(final String author, final int epoch, final String content)
             throws XMLStreamException {
-            return this.changelog();
+            this.xml.writeStartElement("changelog");
+            this.xml.writeAttribute("epoch", String.valueOf(epoch));
+            this.xml.writeAttribute("author", String.valueOf(author));
+            this.xml.writeCharacters(content);
+            this.xml.writeEndElement();
+            return this;
         }
 
         /**

--- a/src/main/java/com/artipie/rpm/pkg/HeaderTags.java
+++ b/src/main/java/com/artipie/rpm/pkg/HeaderTags.java
@@ -230,4 +230,12 @@ public final class HeaderTags {
     public int[] dirIndexes() {
         return this.meta.header(Header.HeaderTag.DIRINDEXES).asInts();
     }
+
+    /**
+     * Get the changelog header.
+     * @return Value of header tag CHANGELOG.
+     */
+    public List<String> changelog() {
+        return this.meta.header(Header.HeaderTag.CHANGELOG).asStrings();
+    }
 }

--- a/src/main/java/com/artipie/rpm/pkg/OthersOutput.java
+++ b/src/main/java/com/artipie/rpm/pkg/OthersOutput.java
@@ -86,7 +86,7 @@ public final class OthersOutput implements PackageOutput.FileOutput {
                 tags.name(), tags.arch(),
                 meta.checksum().hex()
             ).version(tags.epoch(), tags.version(), tags.release())
-                .changelog().close();
+                .changelog(tags.changelog()).close();
         } catch (final XMLStreamException err) {
             throw new IOException("Failed to add package", err);
         }

--- a/src/test/java/com/artipie/rpm/meta/XmlOthersTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlOthersTest.java
@@ -107,7 +107,7 @@ public class XmlOthersTest {
         MatcherAssert.assertThat(
             new String(Files.readAllBytes(xml), StandardCharsets.UTF_8),
             // @checkstyle LineLengthCheck (1 line)
-            XhtmlMatchers.hasXPath("/*[local-name()='otherdata']/*[local-name()='package']/*[local-name()='changelog' and @epoch='0' and @author='Paulo Lobo' and text()='Test for changelog generation']")
+            XhtmlMatchers.hasXPath("/*[local-name()='otherdata']/*[local-name()='package']/*[local-name()='changelog' and @date='0' and @author='Paulo Lobo' and text()='Test for changelog generation']")
         );
     }
 
@@ -139,8 +139,8 @@ public class XmlOthersTest {
             new String(Files.readAllBytes(xml), StandardCharsets.UTF_8),
             // @checkstyle LineLengthCheck (5 lines)
             XhtmlMatchers.hasXPaths(
-                "/*[local-name()='otherdata']/*[local-name()='package']/*[local-name()='changelog' and @epoch='1589338800' and @author='John Doe <johndoe@artipie.org> - 0.1-2' and text()='- Second artipie package']",
-                "/*[local-name()='otherdata']/*[local-name()='package']/*[local-name()='changelog' and @epoch='1464663600' and @author='Jane Doe <janedoe@artipie.org> - 0.1-1' and text()='- First artipie package\n- Example second item in the changelog for version-release 0.1-1']"
+                "/*[local-name()='otherdata']/*[local-name()='package']/*[local-name()='changelog' and @date='1589338800' and @author='John Doe <johndoe@artipie.org> - 0.1-2' and text()='- Second artipie package']",
+                "/*[local-name()='otherdata']/*[local-name()='package']/*[local-name()='changelog' and @date='1464663600' and @author='Jane Doe <janedoe@artipie.org> - 0.1-1' and text()='- First artipie package\n- Example second item in the changelog for version-release 0.1-1']"
             )
         );
     }

--- a/src/test/java/com/artipie/rpm/meta/XmlOthersTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlOthersTest.java
@@ -27,6 +27,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -92,7 +93,6 @@ public class XmlOthersTest {
      * @throws Exception
      */
     @Test
-    @Disabled
     void canAddChangelog(@TempDir final Path tmp) throws Exception {
         final Path xml = tmp.resolve("changelog.xml");
         try (XmlOthers others = new XmlOthers(xml)) {
@@ -108,6 +108,40 @@ public class XmlOthersTest {
             new String(Files.readAllBytes(xml), StandardCharsets.UTF_8),
             // @checkstyle LineLengthCheck (1 line)
             XhtmlMatchers.hasXPath("/*[local-name()='otherdata']/*[local-name()='package']/*[local-name()='changelog' and @epoch='0' and @author='Paulo Lobo' and text()='Test for changelog generation']")
+        );
+    }
+
+    /**
+     * Test adding a changelog list for the package.
+     * @param tmp Temp path
+     * @throws Exception
+     */
+    @Test
+    @Disabled
+    void canAddMultipleChangelogs(@TempDir final Path tmp) throws Exception {
+        final Path xml = tmp.resolve("multiple-changelog.xml");
+        try (XmlOthers others = new XmlOthers(xml)) {
+            others.startPackages();
+            others.addPackage(
+                "ggg", "hhh",
+                "iii"
+            ).version(0, "3.0.0", "9.20190810git9666276.el10")
+            .changelog(
+                // @checkstyle LineLengthCheck (5 lines)
+                new ListOf<>(
+                    "* Wed May 13 2020 John Doe <johndoe@artipie.org> - 0.1-2\n- Second artipie package",
+                    "* Tue May 31 2016 Jane Doe <janedoe@artipie.org> - 0.1-1\n- First artipie package\n- Example second item in the changelog for version-release 0.1-1"
+                )
+            )
+            .close();
+        }
+        MatcherAssert.assertThat(
+            new String(Files.readAllBytes(xml), StandardCharsets.UTF_8),
+            // @checkstyle LineLengthCheck (5 lines)
+            XhtmlMatchers.hasXPaths(
+                "/*[local-name()='otherdata']/*[local-name()='package']/*[local-name()='changelog' and @epoch='1589338800' and @author='John Doe <johndoe@artipie.org> - 0.1-2' and text()='- Second artipie package']",
+                "/*[local-name()='otherdata']/*[local-name()='package']/*[local-name()='changelog' and @epoch='1464663600' and @author='Jane Doe <janedoe@artipie.org> - 0.1-1' and text()='- First artipie package\n- Example second item in the changelog for version-release 0.1-1']"
+            )
         );
     }
 


### PR DESCRIPTION
For #82:
- implemented single changelog appending method
- created test for multiple changelog appending: I've discovered in docs (https://www.techrepublic.com/article/making-rpms-part-4-finishing-the-spec-file/ and https://rpm-packaging-guide.github.io/#packaging-software) how changelog is stored into specs file and modeled `XmlOthers` to receive a list of changelog items.
- left the puzzle for parsing the changelog list and append it to the xml file