### PR TITLE
For #129: Optional filelists on the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ java -jar target/rpm-adapter.jar ./repo-dir/
 Options are:
 - `naming-policy` - (optional, default `simple`) configures NamingPolicy for Rpm
 - `digest` - (optional, default `sha256`) configures Digest instance for Rpm
-- `file-lists` - (optional, default `true`) includes File Lists for Rpm
+- `filelists` - (optional, default `true`) includes File Lists for Rpm
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ java -jar target/rpm-adapter.jar ./repo-dir/
 Options are:
 - `naming-policy` - (optional, default `simple`) configures NamingPolicy for Rpm
 - `digest` - (optional, default `sha256`) configures Digest instance for Rpm
+- `file-lists` - (optional, default `true`) includes File Lists for Rpm
 
 ## How to contribute
 

--- a/src/main/java/com/artipie/rpm/Cli.java
+++ b/src/main/java/com/artipie/rpm/Cli.java
@@ -53,8 +53,6 @@ public final class Cli {
      * Main method of Cli tool.
      *
      * @param args Arguments of command line
-     * @todo #79:30min Right now Rpm always includes filelists - the flag is hard-coded to
-     *  true. Let's make it a command line option to pass to the Rpm class.
      * @checkstyle IllegalCatchCheck (70 lines)
      * @checkstyle LineLengthCheck (50 lines)
      */
@@ -71,6 +69,8 @@ public final class Cli {
         System.out.printf("RPM naming-policy=%s\n", naming);
         final Digest digest = cliargs.digest();
         System.out.printf("RPM digest=%s\n", digest);
+        final boolean filelists = cliargs.fileLists();
+        System.out.printf("RPM file-lists=%s\n", filelists);
         final Path repository = cliargs.repository();
         System.out.printf("RPM repository=%s\n", repository);
         final Vertx vertx = Vertx.vertx();
@@ -83,7 +83,7 @@ public final class Cli {
                     ),
                     naming,
                     digest,
-                    true
+                    filelists
                 )
             ).run();
         } catch (final Exception err) {

--- a/src/main/java/com/artipie/rpm/CliArguments.java
+++ b/src/main/java/com/artipie/rpm/CliArguments.java
@@ -69,7 +69,7 @@ public final class CliArguments {
      */
     private static final Option FILE_LISTS = Option.builder("f")
         .argName("fl")
-        .longOpt("file-list")
+        .longOpt("filelists")
         .desc("(optional, default true) includes File Lists for Rpm: true or false")
         .hasArg()
         .build();

--- a/src/main/java/com/artipie/rpm/CliArguments.java
+++ b/src/main/java/com/artipie/rpm/CliArguments.java
@@ -65,6 +65,16 @@ public final class CliArguments {
         .build();
 
     /**
+     * FileLists option.
+     */
+    private static final Option FILE_LISTS = Option.builder("f")
+        .argName("fl")
+        .longOpt("file-list")
+        .desc("(optional, default true) includes File Lists for Rpm: true or false")
+        .hasArg()
+        .build();
+
+    /**
      * Cli options.
      */
     private final Options options;
@@ -73,7 +83,12 @@ public final class CliArguments {
      * Ctor.
      */
     public CliArguments() {
-        this(new Options().addOption(CliArguments.DIGEST).addOption(CliArguments.NAMING_POLICY));
+        this (
+            new Options()
+                .addOption(CliArguments.DIGEST)
+                .addOption(CliArguments.NAMING_POLICY)
+                .addOption(CliArguments.FILE_LISTS)
+        );
     }
 
     /**
@@ -170,6 +185,18 @@ public final class CliArguments {
                 );
             }
             return Paths.get(args.get(0));
+        }
+
+        /**
+         * Include File Lists.
+         *
+         * @return Boolean.
+         * @throws IllegalArgumentException If the arg value is incorrect
+         */
+        public boolean fileLists() {
+            return Boolean.parseBoolean(
+                this.cli.getOptionValue(CliArguments.FILE_LISTS.getOpt(), "true")
+            );
         }
     }
 }


### PR DESCRIPTION
For #129 :

- Changed `Cli.java` and `CliArguments.java` to accept `filelists` as parameter
- Included information in  `README.md`
