### PR TITLE
Xml join optimization

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlMetaJoin.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlMetaJoin.java
@@ -24,12 +24,16 @@
 package com.artipie.rpm.meta;
 
 import com.jcabi.log.Logger;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLEventWriter;
@@ -43,6 +47,21 @@ import javax.xml.stream.events.XMLEvent;
  * @since 0.9
  */
 public final class XmlMetaJoin {
+
+    /**
+     * Xml header patter.
+     */
+    private static final Pattern HEADER = Pattern.compile("<\\?xml.*?>");
+
+    /**
+     * How many lines to check for xml header and open tag.
+     */
+    private static final int MAX = 5;
+
+    /**
+     * Log line.
+     */
+    private static final String LOG = "%s and %s merged in %[ms]s";
 
     /**
      * Tag.
@@ -79,8 +98,34 @@ public final class XmlMetaJoin {
             throw new IOException(ex);
         }
         Files.move(res, target, StandardCopyOption.REPLACE_EXISTING);
-        Logger.info(
-            this, "%s and %s merged in %[ms]s", target.toString(),
+        Logger.debug(
+            this, XmlMetaJoin.LOG, target.toString(),
+            part.toString(), System.currentTimeMillis() - start
+        );
+    }
+
+    /**
+     * Appends data from part to target.
+     * @param target Target
+     * @param part File to append
+     * @throws IOException On error
+     */
+    @SuppressWarnings({"PMD.PrematureDeclaration", "PMD.GuardLogStatement"})
+    public void fastMerge(final Path target, final Path part) throws IOException {
+        final Path res = target.getParent().resolve(
+            String.format("%s.merged", target.getFileName().toString())
+        );
+        final long start = System.currentTimeMillis();
+        try (BufferedWriter out = Files.newBufferedWriter(res)) {
+            this.writeFirstPart(target, out);
+            this.writeSecondPart(part, out);
+        } catch (final IOException err) {
+            Files.delete(res);
+            throw err;
+        }
+        Files.move(res, target, StandardCopyOption.REPLACE_EXISTING);
+        Logger.debug(
+            this, XmlMetaJoin.LOG, target.toString(),
             part.toString(), System.currentTimeMillis() - start
         );
     }
@@ -108,6 +153,64 @@ public final class XmlMetaJoin {
                 }
             }
             reader.close();
+        }
+    }
+
+    /**
+     * Writes the first part.
+     * @param target What to write
+     * @param writer Where to write
+     * @throws IOException On error
+     */
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    private void writeFirstPart(final Path target, final BufferedWriter writer)
+        throws IOException {
+        try (BufferedReader in = Files.newBufferedReader(target)) {
+            String line;
+            final String close = String.format("</%s>", this.tag);
+            while ((line = in.readLine()) != null) {
+                if (line.contains(close)) {
+                    line = line.replace(close, "");
+                }
+                writer.append(line);
+                writer.newLine();
+            }
+        }
+    }
+
+    /**
+     * Writes the first part.
+     * @param target What to write
+     * @param writer Where to write
+     * @throws IOException On error
+     */
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    private void writeSecondPart(final Path target, final BufferedWriter writer)
+        throws IOException {
+        try (BufferedReader in = Files.newBufferedReader(target)) {
+            String line;
+            int cnt = 0;
+            boolean found = false;
+            final Pattern pattern = Pattern.compile(String.format("<%s.*?>", this.tag));
+            while ((line = in.readLine()) != null) {
+                if (cnt >= XmlMetaJoin.MAX && !found) {
+                    throw new IOException("Failed to merge xml, header not found in part");
+                }
+                if (cnt < XmlMetaJoin.MAX && !found) {
+                    final Matcher mheader = XmlMetaJoin.HEADER.matcher(line);
+                    if (mheader.find()) {
+                        line = mheader.replaceAll("");
+                    }
+                    final Matcher matcher = pattern.matcher(line);
+                    if (matcher.find()) {
+                        line = matcher.replaceAll("");
+                        found = true;
+                    }
+                }
+                cnt = cnt + 1;
+                writer.append(line);
+                writer.newLine();
+            }
         }
     }
 

--- a/src/main/java/com/artipie/rpm/meta/XmlMetaJoin.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlMetaJoin.java
@@ -81,9 +81,11 @@ public final class XmlMetaJoin {
      * @param target Target
      * @param part File to append
      * @throws IOException On error
+     * @todo 200:30min This method have to be removed or moved to `test` scope for test usages:
+     *  it works much slower than the other implementation.
      */
     @SuppressWarnings({"PMD.PrematureDeclaration", "PMD.GuardLogStatement"})
-    public void merge(final Path target, final Path part) throws IOException {
+    public void streamMerge(final Path target, final Path part) throws IOException {
         final long start = System.currentTimeMillis();
         final Path res = target.getParent().resolve(
             String.format("%s.joined", target.getFileName().toString())
@@ -111,7 +113,7 @@ public final class XmlMetaJoin {
      * @throws IOException On error
      */
     @SuppressWarnings({"PMD.PrematureDeclaration", "PMD.GuardLogStatement"})
-    public void fastMerge(final Path target, final Path part) throws IOException {
+    public void merge(final Path target, final Path part) throws IOException {
         final Path res = target.getParent().resolve(
             String.format("%s.merged", target.getFileName().toString())
         );

--- a/src/main/java/com/artipie/rpm/meta/XmlMetaJoin.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlMetaJoin.java
@@ -81,7 +81,7 @@ public final class XmlMetaJoin {
      * @param target Target
      * @param part File to append
      * @throws IOException On error
-     * @todo 200:30min This method have to be removed or moved to `test` scope for test usages:
+     * @todo #200:30min This method have to be removed or moved to `test` scope for test usages:
      *  it works much slower than the other implementation.
      */
     @SuppressWarnings({"PMD.PrematureDeclaration", "PMD.GuardLogStatement"})

--- a/src/main/java/com/artipie/rpm/pkg/ModifiableMetadata.java
+++ b/src/main/java/com/artipie/rpm/pkg/ModifiableMetadata.java
@@ -61,7 +61,8 @@ public final class ModifiableMetadata implements Metadata {
 
     @Override
     public void brush(final List<String> pkgs) throws IOException {
-        new XmlMetaJoin(this.origin.output().tag()).merge(this.origin.output().file(), this.old);
+        new XmlMetaJoin(this.origin.output().tag())
+            .fastMerge(this.origin.output().file(), this.old);
         new XmlAlter(this.origin.output().file()).pkgAttr(
             this.origin.output().tag(), String.valueOf(this.origin.output().maid().clean(pkgs))
         );

--- a/src/main/java/com/artipie/rpm/pkg/ModifiableMetadata.java
+++ b/src/main/java/com/artipie/rpm/pkg/ModifiableMetadata.java
@@ -62,7 +62,7 @@ public final class ModifiableMetadata implements Metadata {
     @Override
     public void brush(final List<String> pkgs) throws IOException {
         new XmlMetaJoin(this.origin.output().tag())
-            .fastMerge(this.origin.output().file(), this.old);
+            .merge(this.origin.output().file(), this.old);
         new XmlAlter(this.origin.output().file()).pkgAttr(
             this.origin.output().tag(), String.valueOf(this.origin.output().maid().clean(pkgs))
         );

--- a/src/test/java/com/artipie/rpm/meta/XmlMetaJoinITCase.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlMetaJoinITCase.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.rpm.meta;
+
+import com.artipie.rpm.files.Gzip;
+import com.artipie.rpm.files.TestBundle;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.Optional;
+import org.apache.commons.io.FileUtils;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+import org.xmlunit.matchers.CompareMatcher;
+
+/**
+ * Test for {@link XmlMetaJoin}.
+ * @since 0.9
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@EnabledIfSystemProperty(named = "it.longtests.enabled", matches = "true")
+class XmlMetaJoinITCase {
+    /**
+     * Temporary directory for all tests.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @TempDir
+    static Path tmp;
+
+    /**
+     * Gzipped bundle of RPMs.
+     */
+    private static Path bundle;
+
+    /**
+     * Gzipped bundle of RPMs.
+     */
+    private static Path repo;
+
+    /**
+     * Resources dir.
+     */
+    private static final String RESOURCES = "src/test/resources-binary/repodata";
+
+    @BeforeAll
+    static void setUpClass() throws Exception {
+        XmlMetaJoinITCase.bundle = new TestBundle(
+            TestBundle.Size.valueOf(
+                System.getProperty("it.longtests.size", "hundred")
+                    .toUpperCase(Locale.US)
+            )
+        ).unpack(XmlMetaJoinITCase.tmp);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        XmlMetaJoinITCase.repo = Files.createDirectory(XmlMetaJoinITCase.tmp.resolve("repo"));
+        new Gzip(XmlMetaJoinITCase.bundle).unpackTar(XmlMetaJoinITCase.repo);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        FileUtils.deleteDirectory(XmlMetaJoinITCase.repo.toFile());
+    }
+
+    @Test
+    void joinsBigMetadataWithSmall() throws IOException {
+        final Path fast = XmlMetaJoinITCase.repo.resolve("big.primary.xml");
+        new Gzip(meta(XmlMetaJoinITCase.repo, "primary")).unpack(fast);
+        new XmlMetaJoin("metadata")
+            .fastMerge(fast, Paths.get(XmlMetaJoinITCase.RESOURCES, "primary.xml.example"));
+        final Path stream = XmlMetaJoinITCase.repo.resolve("big.primary.xml");
+        new Gzip(meta(XmlMetaJoinITCase.repo, "primary")).unpack(stream);
+        new XmlMetaJoin("metadata")
+            .merge(stream, Paths.get(XmlMetaJoinITCase.RESOURCES, "primary.xml.example"));
+        MatcherAssert.assertThat(
+            fast,
+            CompareMatcher.isIdenticalTo(stream)
+        );
+    }
+
+    @Test
+    void joinsSmallMetadataWithBig() throws IOException {
+        final Path big = XmlMetaJoinITCase.repo.resolve("big.filelists.xml");
+        final Path resfast = XmlMetaJoinITCase.repo.resolve("fast.filelists.xml");
+        Files.copy(Paths.get(XmlMetaJoinITCase.RESOURCES, "filelists.xml.example"), resfast);
+        new Gzip(meta(XmlMetaJoinITCase.repo, "filelists")).unpack(big);
+        new XmlMetaJoin("filelists").fastMerge(resfast, big);
+        final Path resstream = XmlMetaJoinITCase.repo.resolve("stream.filelists.xml");
+        Files.copy(Paths.get(XmlMetaJoinITCase.RESOURCES, "filelists.xml.example"), resstream);
+        new XmlMetaJoin("filelists").merge(resstream, big);
+        MatcherAssert.assertThat(
+            resfast,
+            CompareMatcher.isIdenticalTo(resstream)
+        );
+    }
+
+    /**
+     * Searches for the meta file by substring in folder.
+     * @param dir Where to look for the file
+     * @param substr What to find
+     * @return Path to find
+     * @throws IOException On error
+     */
+    private static Path meta(final Path dir, final String substr) throws IOException {
+        final Optional<Path> res = Files.walk(dir)
+            .filter(
+                path -> path.getFileName().toString().endsWith(String.format("%s.xml.gz", substr))
+            ).findFirst();
+        if (res.isPresent()) {
+            return res.get();
+        } else {
+            throw new IllegalStateException(
+                String.format("Metafile %s does not exists in %s", substr, dir.toString())
+            );
+        }
+    }
+
+}

--- a/src/test/java/com/artipie/rpm/meta/XmlMetaJoinITCase.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlMetaJoinITCase.java
@@ -96,11 +96,11 @@ class XmlMetaJoinITCase {
         final Path fast = XmlMetaJoinITCase.repo.resolve("big.primary.xml");
         new Gzip(meta(XmlMetaJoinITCase.repo, "primary")).unpack(fast);
         new XmlMetaJoin("metadata")
-            .fastMerge(fast, Paths.get(XmlMetaJoinITCase.RESOURCES, "primary.xml.example"));
+            .merge(fast, Paths.get(XmlMetaJoinITCase.RESOURCES, "primary.xml.example"));
         final Path stream = XmlMetaJoinITCase.repo.resolve("big.primary.xml");
         new Gzip(meta(XmlMetaJoinITCase.repo, "primary")).unpack(stream);
         new XmlMetaJoin("metadata")
-            .merge(stream, Paths.get(XmlMetaJoinITCase.RESOURCES, "primary.xml.example"));
+            .streamMerge(stream, Paths.get(XmlMetaJoinITCase.RESOURCES, "primary.xml.example"));
         MatcherAssert.assertThat(
             fast,
             CompareMatcher.isIdenticalTo(stream)
@@ -113,10 +113,10 @@ class XmlMetaJoinITCase {
         final Path resfast = XmlMetaJoinITCase.repo.resolve("fast.filelists.xml");
         Files.copy(Paths.get(XmlMetaJoinITCase.RESOURCES, "filelists.xml.example"), resfast);
         new Gzip(meta(XmlMetaJoinITCase.repo, "filelists")).unpack(big);
-        new XmlMetaJoin("filelists").fastMerge(resfast, big);
+        new XmlMetaJoin("filelists").merge(resfast, big);
         final Path resstream = XmlMetaJoinITCase.repo.resolve("stream.filelists.xml");
         Files.copy(Paths.get(XmlMetaJoinITCase.RESOURCES, "filelists.xml.example"), resstream);
-        new XmlMetaJoin("filelists").merge(resstream, big);
+        new XmlMetaJoin("filelists").streamMerge(resstream, big);
         MatcherAssert.assertThat(
             resfast,
             CompareMatcher.isIdenticalTo(resstream)

--- a/src/test/java/com/artipie/rpm/meta/XmlMetaJoinTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlMetaJoinTest.java
@@ -61,6 +61,22 @@ class XmlMetaJoinTest {
     }
 
     @Test
+    void joinsTwoMetaXmlFilesFast(@TempDir final Path temp) throws IOException {
+        final Path file = Files.copy(
+            Paths.get(XmlMetaJoinTest.REPO, "primary.xml.example.first"), temp.resolve("target.xml")
+        );
+        new XmlMetaJoin("metadata").fastMerge(
+            file, Paths.get(XmlMetaJoinTest.REPO, "primary.xml.example.second")
+        );
+        MatcherAssert.assertThat(
+            file,
+            CompareMatcher.isIdenticalTo(
+                Paths.get(XmlMetaJoinTest.REPO, "primary.xml.example")
+            )
+        );
+    }
+
+    @Test
     void joinsWhenXmlIsNotProperlyFormatted(@TempDir final Path temp) throws IOException {
         final Path target = temp.resolve("res.xml");
         final Path part = temp.resolve("part.xml");
@@ -83,6 +99,46 @@ class XmlMetaJoinTest {
             ).getBytes()
         );
         new XmlMetaJoin("parent").merge(target, part);
+        final Path expected = temp.resolve("expected.xml");
+        Files.write(
+            expected,
+            String.join(
+                "\n",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<parent>",
+                "<a>1</a><b>2</b><c>2</c><d>3</d>",
+                "</parent>"
+            ).getBytes()
+        );
+        MatcherAssert.assertThat(
+            target,
+            CompareMatcher.isIdenticalTo(expected)
+        );
+    }
+
+    @Test
+    void joinsFastWhenXmlIsNotProperlyFormatted(@TempDir final Path temp) throws IOException {
+        final Path target = temp.resolve("res.xml");
+        final Path part = temp.resolve("part.xml");
+        Files.write(
+            target,
+            String.join(
+                "\n",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<a>1</a>",
+                "<b>2</b></parent>"
+            ).getBytes()
+        );
+        Files.write(
+            part,
+            String.join(
+                "\n",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?> <parent>",
+                "<c>2</c>",
+                "<d>3</d></parent>"
+            ).getBytes()
+        );
+        new XmlMetaJoin("parent").fastMerge(target, part);
         final Path expected = temp.resolve("expected.xml");
         Files.write(
             expected,

--- a/src/test/java/com/artipie/rpm/meta/XmlMetaJoinTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlMetaJoinTest.java
@@ -49,7 +49,7 @@ class XmlMetaJoinTest {
         final Path file = Files.copy(
             Paths.get(XmlMetaJoinTest.REPO, "primary.xml.example.first"), temp.resolve("target.xml")
         );
-        new XmlMetaJoin("metadata").merge(
+        new XmlMetaJoin("metadata").streamMerge(
             file, Paths.get(XmlMetaJoinTest.REPO, "primary.xml.example.second")
         );
         MatcherAssert.assertThat(
@@ -65,7 +65,7 @@ class XmlMetaJoinTest {
         final Path file = Files.copy(
             Paths.get(XmlMetaJoinTest.REPO, "primary.xml.example.first"), temp.resolve("target.xml")
         );
-        new XmlMetaJoin("metadata").fastMerge(
+        new XmlMetaJoin("metadata").merge(
             file, Paths.get(XmlMetaJoinTest.REPO, "primary.xml.example.second")
         );
         MatcherAssert.assertThat(
@@ -98,7 +98,7 @@ class XmlMetaJoinTest {
                 "<d>3</d></parent>"
             ).getBytes()
         );
-        new XmlMetaJoin("parent").merge(target, part);
+        new XmlMetaJoin("parent").streamMerge(target, part);
         final Path expected = temp.resolve("expected.xml");
         Files.write(
             expected,
@@ -138,7 +138,7 @@ class XmlMetaJoinTest {
                 "<d>3</d></parent>"
             ).getBytes()
         );
-        new XmlMetaJoin("parent").fastMerge(target, part);
+        new XmlMetaJoin("parent").merge(target, part);
         final Path expected = temp.resolve("expected.xml");
         Files.write(
             expected,

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -4,5 +4,6 @@ log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=com.jcabi.log.MulticolorLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=[%color{%p}] %t %c: %m%n
 log4j.logger.com.artipie.rpm.files=DEBUG
+log4j.logger.com.artipie.rpm.meta=DEBUG
 
 


### PR DESCRIPTION
Optimized `XmlMetaJoin` by getting rid of xml steams as requested in #200. New implementation works faster:
```
//buffered reader
[DEBUG] main com.artipie.rpm.meta.XmlMetaJoin: /tmp/junit18146090115461577170/repo/fast.filelists.xml and /tmp/junit18146090115461577170/repo/big.filelists.xml merged in 138ms
//xml stream
[DEBUG] main com.artipie.rpm.meta.XmlMetaJoin: /tmp/junit18146090115461577170/repo/stream.filelists.xml and /tmp/junit18146090115461577170/repo/big.filelists.xml merged in 15s
```
For now I've decided to keep xml steams implementation for tests. 