### PR TITLE
For #113: added CliArguments tests

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -17,6 +17,8 @@ deploy:
     echo There is nothing to deploy
     exit 1
 release:
+  sensitive:
+    - settings.xml
   script: |-
     pdd -f /dev/null
     gpg --import /home/r/pubring.gpg
@@ -27,3 +29,4 @@ release:
 architect:
   - g4s8
   - yegor256
+

--- a/src/main/java/com/artipie/rpm/CliArguments.java
+++ b/src/main/java/com/artipie/rpm/CliArguments.java
@@ -38,9 +38,11 @@ import org.apache.commons.cli.ParseException;
  * Cli tool argument parsing.
  *
  * @since 0.9
- * @todo #89:30min Cli options are not parsed correctly. getOptionValue method always return
- *  default value for both options, so it's not possible to override them. But the tool is working
- *  correctly. To build it use `cli` maven profile, see the README.
+ * @todo #113:30min Fix errors when parsing arguments.
+ *  Cli options are not parsed correctly, argumens namingpolicy and digest
+ *  cannot be set up through cli. There are already tests for this behavior
+ *  on CliArgumentsTest. Fix this and then activate the tests and add a test
+ *  for an execution with all arguments.
  */
 public final class CliArguments {
 

--- a/src/main/java/com/artipie/rpm/CliArguments.java
+++ b/src/main/java/com/artipie/rpm/CliArguments.java
@@ -38,11 +38,11 @@ import org.apache.commons.cli.ParseException;
  * Cli tool argument parsing.
  *
  * @since 0.9
- * @todo #113:30min Fix errors when parsing arguments.
- *  Cli options are not parsed correctly, argumens namingpolicy and digest
- *  cannot be set up through cli. There are already tests for this behavior
- *  on CliArgumentsTest. Fix this and then activate the tests and add a test
- *  for an execution with all arguments.
+ * @todo #113:30min Improve CliArgument behavior.
+ *  Currently CliArgument requires the argument value to be informed immediately
+ *  after the argument (i.e. -psha1, -ffalse, -dsha256). It would be more
+ *  readable if the argument values were preceded by a whitespace (-p sha1,
+ *  -f false, -d sha256, etc)
  */
 public final class CliArguments {
 

--- a/src/main/java/com/artipie/rpm/CliArguments.java
+++ b/src/main/java/com/artipie/rpm/CliArguments.java
@@ -37,12 +37,10 @@ import org.apache.commons.cli.ParseException;
 /**
  * Cli tool argument parsing.
  *
+ * Arguments values must be passed immediately after argument declaration (e.g
+ * -dsha256) or after ´=´ signal (e.g -d=sha256).
+ *
  * @since 0.9
- * @todo #113:30min Improve CliArgument behavior.
- *  Currently CliArgument requires the argument value to be informed immediately
- *  after the argument (i.e. -psha1, -ffalse, -dsha256). It would be more
- *  readable if the argument values were preceded by a whitespace (-p sha1,
- *  -f false, -d sha256, etc)
  */
 public final class CliArguments {
 

--- a/src/test/java/com/artipie/rpm/CliArgumentsTest.java
+++ b/src/test/java/com/artipie/rpm/CliArgumentsTest.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.rpm;
+
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link CliArguments}.
+ *
+ * @since 0.9
+ */
+class CliArgumentsTest {
+
+    @Test
+    void canParseRepositoryArgument(@TempDir final Path temp) {
+        MatcherAssert.assertThat(
+            new CliArguments().parsed(
+                String.format(
+                    "%s",
+                    temp.getFileName()
+                )
+            ).repository(),
+            new IsEqual<>(temp.getFileName())
+        );
+    }
+
+    @Test
+    @Disabled
+    void canParseNamingPolicyArgument(@TempDir final Path temp) {
+        MatcherAssert.assertThat(
+            new CliArguments().parsed(
+                "-np sha1"
+            ).naming(),
+            new IsEqual<>(StandardNamingPolicy.SHA1)
+        );
+    }
+
+    @Test
+    void canParseFileListsArgument(@TempDir final Path temp) {
+        MatcherAssert.assertThat(
+            new CliArguments().parsed(
+                "-fl false"
+            ).fileLists(),
+            new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    @Disabled
+    void canParseDigestArgument(@TempDir final Path temp) {
+        MatcherAssert.assertThat(
+            new CliArguments().parsed(
+                "-dgst sha1"
+            ).digest(),
+            new IsEqual<>(Digest.SHA1)
+        );
+    }
+}

--- a/src/test/java/com/artipie/rpm/CliArgumentsTest.java
+++ b/src/test/java/com/artipie/rpm/CliArgumentsTest.java
@@ -26,7 +26,6 @@ package com.artipie.rpm;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -34,6 +33,8 @@ import org.junit.jupiter.api.io.TempDir;
  * Tests for {@link CliArguments}.
  *
  * @since 0.9
+ * @todo #113:30min Add more tests for CliArgumentTests.
+ *  Add tests for CliArguments using all arguments and longopt name arguments.
  */
 class CliArgumentsTest {
 
@@ -51,11 +52,10 @@ class CliArgumentsTest {
     }
 
     @Test
-    @Disabled
     void canParseNamingPolicyArgument(@TempDir final Path temp) {
         MatcherAssert.assertThat(
             new CliArguments().parsed(
-                "-np sha1"
+                "-nsha1"
             ).naming(),
             new IsEqual<>(StandardNamingPolicy.SHA1)
         );
@@ -65,18 +65,17 @@ class CliArgumentsTest {
     void canParseFileListsArgument(@TempDir final Path temp) {
         MatcherAssert.assertThat(
             new CliArguments().parsed(
-                "-fl false"
+                "-ffalse"
             ).fileLists(),
             new IsEqual<>(false)
         );
     }
 
     @Test
-    @Disabled
     void canParseDigestArgument(@TempDir final Path temp) {
         MatcherAssert.assertThat(
             new CliArguments().parsed(
-                "-dgst sha1"
+                "-dsha1"
             ).digest(),
             new IsEqual<>(Digest.SHA1)
         );

--- a/src/test/java/com/artipie/rpm/CliArgumentsTest.java
+++ b/src/test/java/com/artipie/rpm/CliArgumentsTest.java
@@ -34,7 +34,8 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @since 0.9
  * @todo #113:30min Add more tests for CliArgumentTests.
- *  Add tests for CliArguments using all arguments and longopt name arguments.
+ *  Add tests for CliArguments using all arguments, '=' signal for setting
+ *  argument values and longopt name arguments.
  */
 class CliArgumentsTest {
 


### PR DESCRIPTION
For #113:
- Added `CliArguments` tests for all expected arguments
- Left puzzle for fixing `naming` and `digest` arguments parsing, since they don't work
