### PR TITLE
For #117: Added assertions to XmlPrimaryTest

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlPrimary.java
@@ -39,6 +39,19 @@ import javax.xml.stream.XMLStreamException;
  * </p>
  *
  * @since 0.6
+ *
+ * @todo #117:30min Fix metadata 'packages' attribute
+ *  XmlPrimary is generating 'packages' attribute in 'metadata' element with
+ *  the wrong value. Correct this (it should reflect the number of packages
+ *  described in primary.xml file) and then add a check to this value on
+ *  XmlPrimaryTest.
+ * @todo #117:30min Fix 'provides' element generation
+ *  XmlPrimary is not generating 'provides' elements correctly. Actually
+ *  it does not generate a 'provides' element at all: it should generate an
+ *  element named 'provides' with child entries containing 'name', 'flags',
+ *  'epoch' and 'ver' attributes. Refer to primary.xml.example file for
+ *  more details. The test in XmlPrimaryTest must be updated once 'provides'
+ *  element generation is fixed.
  */
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
 public final class XmlPrimary implements Closeable {

--- a/src/test/java/com/artipie/rpm/meta/XmlPrimaryTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlPrimaryTest.java
@@ -66,7 +66,7 @@ public final class XmlPrimaryTest {
                 .buildHost("http://giuthub.com/artipie/rpm-adapter/buildhost")
                 .sourceRpm("primary.src.rpm")
                 .requires(
-                    new ListOf<String>(
+                    new ListOf<>(
                         "ld-linux-aarch64.so.1()(64bit)"
                     )
                 )

--- a/src/test/java/com/artipie/rpm/meta/XmlPrimaryTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlPrimaryTest.java
@@ -23,7 +23,12 @@
  */
 package com.artipie.rpm.meta;
 
+import com.jcabi.matchers.XhtmlMatchers;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -33,25 +38,64 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 0.6
  */
 public final class XmlPrimaryTest {
-    // @todo #83:30min This test only creates a temporary file for XmlPrimary,
-    //  now some assertion should be added to verify that this class
-    //  can write `primary.xml` file correctly. The example of primary can
-    //  be found at test resources. If #86 is fixed then remove the DisabledOnOs
-    //  annotation.
     @Test
     public void writesFile(@TempDir final Path temp) throws Exception {
         final Path file = temp.resolve("primary.xml");
         try (XmlPrimary prim = new XmlPrimary(file)) {
+            // @checkstyle MagicNumberCheck (20 lines)
             prim.startPackages()
                 .startPackage()
+                .name("primary")
+                .arch("arch")
+                .version(0, "0.0.1", "8.20190810git9666276.el8")
+                .summary("Package test for XmlPrimary")
+                .description("This is a package to test XmlPrimary behavior")
+                .packager("artipie")
+                .url("http://giuthub.com/artipie/rpm-adapter")
+                .time(5, 7)
+                .size(15L, 9, 2)
+                .location("http://github.com/artipie/rpm-adapter/primary.rpm")
                 .files(
                     new String[] {"file" },
                     new String[] {"dir" },
                     new int[] {0 }
                 ).startFormat()
                 .license("license")
+                .vendor("vendor")
+                .group("Unspecified")
+                .buildHost("http://giuthub.com/artipie/rpm-adapter/buildhost")
+                .sourceRpm("primary.src.rpm")
+                .requires(
+                    new ListOf<String>(
+                        "ld-linux-aarch64.so.1()(64bit)"
+                    )
+                )
                 .close()
                 .close();
         }
+        MatcherAssert.assertThat(
+            new String(Files.readAllBytes(file), StandardCharsets.UTF_8),
+            // @checkstyle LineLengthCheck (20 lines)
+            XhtmlMatchers.hasXPaths(
+                "/*[local-name()='metadata']/*[local-name()='package' and @type='rpm']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='name' and text()='primary']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='arch' and text()='arch']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='version' and @epoch='0' and @ver='0.0.1' and @rel='8.20190810git9666276.el8']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='summary' and text()='Package test for XmlPrimary']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='description' and text()='This is a package to test XmlPrimary behavior']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='packager' and text()='artipie']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='url' and text()='http://giuthub.com/artipie/rpm-adapter']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='time' and @file='5' and @build='7']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='size' and @package='15' and @installed='9' and @archive='2']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='location' and @href='http://github.com/artipie/rpm-adapter/primary.rpm']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='file' and text()='dirfile']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='format']/*[name()='rpm:license' and text()='license']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='format']/*[name()='rpm:vendor' and text()='vendor']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='format']/*[name()='rpm:group' and text()='Unspecified']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='format']/*[name()='rpm:buildhost' and text()='http://giuthub.com/artipie/rpm-adapter/buildhost']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='format']/*[name()='rpm:sourcerpm' and text()='primary.src.rpm']",
+                "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='format']/*[name()='rpm:requires']/*[name()='rpm:entry' and @name='ld-linux-aarch64.so.1()(64bit)']"
+            )
+        );
     }
 }


### PR DESCRIPTION
For #117: 
- Added assertions to check if `XmlPrimary` is generating correct XML
- `XmlPrimary` is not generating the file correctly; it has problems in `/metadata[@packages]` and in `/rpm:provides`. I've left two puzzles to fix these errors and add tests to `XmlPrimaryTest`