### PR TITLE
#203 - add timing extension for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@ SOFTWARE.
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.65</minimum>
+                      <minimum>0.64</minimum>
                     </limit>
                     <limit>
                       <counter>BRANCH</counter>

--- a/src/main/java/com/artipie/rpm/meta/XmlMetaJoin.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlMetaJoin.java
@@ -23,7 +23,6 @@
  */
 package com.artipie.rpm.meta;
 
-import com.jcabi.log.Logger;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -73,7 +72,6 @@ public final class XmlMetaJoin {
         final Path res = target.getParent().resolve(
             String.format("%s.merged", target.getFileName().toString())
         );
-        final long start = System.currentTimeMillis();
         try (BufferedWriter out = Files.newBufferedWriter(res)) {
             this.writeFirstPart(target, out);
             this.writeSecondPart(part, out);
@@ -82,10 +80,6 @@ public final class XmlMetaJoin {
             throw err;
         }
         Files.move(res, target, StandardCopyOption.REPLACE_EXISTING);
-        Logger.debug(
-            this, "%s and %s merged in %[ms]s", target.toString(),
-            part.toString(), System.currentTimeMillis() - start
-        );
     }
 
     /**

--- a/src/test/java/com/artipie/rpm/RpmITCase.java
+++ b/src/test/java/com/artipie/rpm/RpmITCase.java
@@ -31,7 +31,6 @@ import com.artipie.asto.fs.FileStorage;
 import com.artipie.rpm.files.Gzip;
 import com.artipie.rpm.files.TestBundle;
 import com.artipie.rpm.misc.UncheckedConsumer;
-import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -48,6 +47,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -62,8 +62,9 @@ import org.junit.jupiter.api.io.TempDir;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.GuardLogStatement"})
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @EnabledIfSystemProperty(named = "it.longtests.enabled", matches = "true")
+@ExtendWith(TimingExtension.class)
 final class RpmITCase {
 
     /**
@@ -119,23 +120,17 @@ final class RpmITCase {
 
     @Test
     void generatesMetadata() {
-        final long start = System.currentTimeMillis();
         new Rpm(this.storage, StandardNamingPolicy.SHA1, Digest.SHA256, true)
             .batchUpdate(Key.ROOT)
             .blockingAwait();
-        Logger.info(this, "Repo updated in %[ms]s", System.currentTimeMillis() - start);
     }
 
     @Test
     void generatesMetadataIncrementally() throws IOException, InterruptedException {
-        final long start = System.currentTimeMillis();
         this.modifyRepo();
         new Rpm(this.storage, StandardNamingPolicy.SHA1, Digest.SHA256, true)
             .updateBatchIncrementally(Key.ROOT)
             .blockingAwait();
-        Logger.info(
-            this, "Repo updated incrementally in %[ms]s", System.currentTimeMillis() - start
-        );
     }
 
     @Test

--- a/src/test/java/com/artipie/rpm/TimingExtension.java
+++ b/src/test/java/com/artipie/rpm/TimingExtension.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.rpm;
+
+import com.jcabi.log.Logger;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+
+/**
+ * Junit extension to measure test time execution.
+ * @since 1.0
+ * @checkstyle JavadocVariableCheck (500 lines)
+ */
+@SuppressWarnings("PMD.GuardLogStatement")
+public final class TimingExtension implements BeforeTestExecutionCallback,
+    AfterTestExecutionCallback {
+
+    private static final String START_TIME = "start time";
+
+    @Override
+    public void beforeTestExecution(final ExtensionContext context) {
+        this.getStore(context).put(TimingExtension.START_TIME, System.currentTimeMillis());
+    }
+
+    @Override
+    public void afterTestExecution(final ExtensionContext context) {
+        final Method method = context.getRequiredTestMethod();
+        final long start = this.getStore(context)
+            .remove(TimingExtension.START_TIME, long.class);
+        Logger.info(
+            context.getRequiredTestClass(),
+            "Method %s took %[ms]s",
+            method.getName(),
+            System.currentTimeMillis() - start
+        );
+    }
+
+    /**
+     * Returns store from context.
+     * @param context Extension context
+     * @return Junit store
+     */
+    private Store getStore(final ExtensionContext context) {
+        return context.getStore(
+            Namespace.create(this.getClass(), context.getRequiredTestMethod())
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/rpm/TimingExtension.java
+++ b/src/test/java/com/artipie/rpm/TimingExtension.java
@@ -24,7 +24,6 @@
 package com.artipie.rpm;
 
 import com.jcabi.log.Logger;
-import java.lang.reflect.Method;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -49,13 +48,12 @@ public final class TimingExtension implements BeforeTestExecutionCallback,
 
     @Override
     public void afterTestExecution(final ExtensionContext context) {
-        final Method method = context.getRequiredTestMethod();
         final long start = this.getStore(context)
             .remove(TimingExtension.START_TIME, long.class);
         Logger.info(
             context.getRequiredTestClass(),
             "Method %s took %[ms]s",
-            method.getName(),
+            context.getRequiredTestMethod().getName(),
             System.currentTimeMillis() - start
         );
     }

--- a/src/test/java/com/artipie/rpm/meta/XmlStreamJoin.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlStreamJoin.java
@@ -23,7 +23,6 @@
  */
 package com.artipie.rpm.meta;
 
-import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -65,7 +64,6 @@ public final class XmlStreamJoin {
      */
     @SuppressWarnings({"PMD.PrematureDeclaration", "PMD.GuardLogStatement"})
     public void merge(final Path target, final Path part) throws IOException {
-        final long start = System.currentTimeMillis();
         final Path res = target.getParent().resolve(
             String.format("%s.joined", target.getFileName().toString())
         );
@@ -79,10 +77,6 @@ public final class XmlStreamJoin {
             throw new IOException(ex);
         }
         Files.move(res, target, StandardCopyOption.REPLACE_EXISTING);
-        Logger.debug(
-            this, "%s and %s merged with xml-streams in %[ms]s", target.toString(),
-            part.toString(), System.currentTimeMillis() - start
-        );
     }
 
     /**


### PR DESCRIPTION
For #203 added `TimingExtension` for junit, used it in itcases and removed logging in main classes.