### PR TITLE
#190 - Throwing InvalidPackageException when package failed to be parsed

### DIFF
--- a/src/main/java/com/artipie/rpm/pkg/FilePackage.java
+++ b/src/main/java/com/artipie/rpm/pkg/FilePackage.java
@@ -91,22 +91,31 @@ public final class FilePackage implements Package {
     /**
      * Parsed file package.
      * @return Parsed package
+     * @throws InvalidPackageException In case package is invalid.
      * @throws IOException On error
      */
-    public Package parsed() throws IOException {
+    public Package parsed() throws InvalidPackageException, IOException {
         return new ParsedFilePackage(this.header(), this.file);
     }
 
     /**
      * Get header.
      * @return The header
+     * @throws InvalidPackageException In case package is invalid.
      * @throws IOException On error
      */
-    private Header header() throws IOException {
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private Header header() throws InvalidPackageException, IOException {
         try (FileChannel chan = FileChannel.open(this.file, StandardOpenOption.READ)) {
-            final Format format = new Scanner(
-                new PrintStream(Logger.stream(Level.FINE, this))
-            ).run(new ReadableChannelWrapper(chan));
+            final Format format;
+            try {
+                format = new Scanner(
+                    new PrintStream(Logger.stream(Level.FINE, this))
+                ).run(new ReadableChannelWrapper(chan));
+                // @checkstyle IllegalCatchCheck (1 line)
+            } catch (final RuntimeException ex) {
+                throw new InvalidPackageException(ex);
+            }
             final Header header = format.getHeader();
             Logger.debug(this, "header: %s", header.toString());
             return header;

--- a/src/main/java/com/artipie/rpm/pkg/InvalidPackageException.java
+++ b/src/main/java/com/artipie/rpm/pkg/InvalidPackageException.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.rpm.pkg;
+
+/**
+ * Exception indicates that package is invalid.
+ *
+ * @since 0.8.3
+ */
+@SuppressWarnings("serial")
+public class InvalidPackageException extends RuntimeException {
+    /**
+     * Ctor.
+     *
+     * @param cause Underlying cause for package being invalid.
+     */
+    public InvalidPackageException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/com/artipie/rpm/RpmTest.java
+++ b/src/test/java/com/artipie/rpm/RpmTest.java
@@ -40,9 +40,10 @@ import org.junit.jupiter.api.io.TempDir;
  * Unit tests for {@link Rpm}.
  *
  * @since 0.9
- * @todo #63:30min Don't change metadata when invalid package is sent.
+ * @todo #190:30min Don't change metadata when invalid package is sent.
  *  Currently Rpm is recalculating metadata when an invalid package is sent.
  *  It should not. Correct that and enable the test below.
+ *  To do that `InvalidPackageException` should be caught when parsing packages.
  */
 final class RpmTest {
 

--- a/src/test/java/com/artipie/rpm/pkg/FilePackageHeadersTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/FilePackageHeadersTest.java
@@ -24,10 +24,13 @@
 package com.artipie.rpm.pkg;
 
 import com.artipie.rpm.Digest;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.redline_rpm.header.Header;
@@ -57,7 +60,7 @@ public final class FilePackageHeadersTest {
     public void parseStringsHeader(@TempDir final Path unused) throws Exception {
         final Header.HeaderTag tag = Header.HeaderTag.NAME;
         final Header header = new Header();
-        final String[] expected = new String[] {"s1", "s2" };
+        final String[] expected = new String[]{"s1", "s2"};
         header.createEntry(tag, expected);
         MatcherAssert.assertThat(
             new FilePackage.Headers(
@@ -85,7 +88,7 @@ public final class FilePackageHeadersTest {
     public void parseIntsHeader(@TempDir final Path unused) throws Exception {
         final Header.HeaderTag tag = Header.HeaderTag.EPOCH;
         final Header header = new Header();
-        final int[] expected = new int[] {0, 1 };
+        final int[] expected = new int[]{0, 1};
         header.createEntry(tag, expected);
         MatcherAssert.assertThat(
             new FilePackage.Headers(
@@ -115,5 +118,19 @@ public final class FilePackageHeadersTest {
             ).header(Header.HeaderTag.EPOCH).asInt(expected),
             new IsEqual<>(expected)
         );
+    }
+
+    @Test
+    public void failParseInvalidPackageFile(@TempDir final Path tmp) throws Exception {
+        final Path invalid = tmp.resolve("invalid.rpm");
+        Files.write(invalid, "invalid".getBytes());
+        final FilePackage pack = new FilePackage(invalid);
+        Assertions.assertThrows(InvalidPackageException.class, pack::parsed);
+    }
+
+    @Test
+    public void failParseNotExistingPackageFile(@TempDir final Path tmp) {
+        final FilePackage pack = new FilePackage(tmp.resolve("not-exists.rpm"));
+        Assertions.assertThrows(IOException.class, pack::parsed);
     }
 }


### PR DESCRIPTION
Part of #190 
Throwing InvalidPackageException when package failed to be parsed.
This is required to distinguish bad package from other problems when package is parsed, such as I/O errors