### PR TITLE
#192 - no blocking operations on incremental update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.20.1</version>
+      <version>0.20.4</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
Restructured `Rpm#updateBatchIncrementally` to get rid of blocking operations for #192.