### PR TITLE
#191 - Added date parsing to ChangelogEntry

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/ChangelogEntry.java
+++ b/src/main/java/com/artipie/rpm/meta/ChangelogEntry.java
@@ -77,8 +77,7 @@ final class ChangelogEntry {
      * @return Date in UNIX time.
      */
     int date() {
-        final Matcher matcher = this.matcher();
-        final String str = matcher.group("date");
+        final String str = this.matcher().group("date");
         final SimpleDateFormat format = new SimpleDateFormat("EEE MMM dd yyyy", Locale.US);
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
         final Date date;

--- a/src/main/java/com/artipie/rpm/meta/ChangelogEntry.java
+++ b/src/main/java/com/artipie/rpm/meta/ChangelogEntry.java
@@ -23,6 +23,13 @@
  */
 package com.artipie.rpm.meta;
 
+import com.google.common.primitives.Ints;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -37,7 +44,7 @@ final class ChangelogEntry {
      * RegEx pattern of changelog entry string.
      */
     private static final Pattern PATTERN = Pattern.compile(
-        "\\* \\w+ \\w+ \\d+ \\d+ (?<author>[^-]+) (?<content>-.*)",
+        "\\* (?<date>\\w+ \\w+ \\d+ \\d+) (?<author>[^-]+) (?<content>-.*)",
         Pattern.DOTALL
     );
 
@@ -62,6 +69,25 @@ final class ChangelogEntry {
      */
     String author() {
         return this.matcher().group("author");
+    }
+
+    /**
+     * Read date.
+     *
+     * @return Date in UNIX time.
+     */
+    int date() {
+        final Matcher matcher = this.matcher();
+        final String str = matcher.group("date");
+        final SimpleDateFormat format = new SimpleDateFormat("EEE MMM dd yyyy", Locale.US);
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        final Date date;
+        try {
+            date = format.parse(str);
+        } catch (final ParseException ex) {
+            throw new IllegalStateException(String.format("Failed to parse date: '%s'", str), ex);
+        }
+        return Ints.checkedCast(TimeUnit.MILLISECONDS.toSeconds(date.getTime()));
     }
 
     /**

--- a/src/test/java/com/artipie/rpm/meta/ChangelogEntryTest.java
+++ b/src/test/java/com/artipie/rpm/meta/ChangelogEntryTest.java
@@ -25,6 +25,7 @@ package com.artipie.rpm.meta;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,17 +35,12 @@ import org.junit.jupiter.api.Test;
  */
 class ChangelogEntryTest {
 
-    /**
-     * Entry tested.
-     */
-    private final ChangelogEntry entry = new ChangelogEntry(
-        "* Wed May 13 2020 John Doe <johndoe@artipie.org> - 0.1-2\n- Second artipie package"
-    );
-
     @Test
     void shouldParseAuthor() {
         MatcherAssert.assertThat(
-            this.entry.author(),
+            new ChangelogEntry(
+                "* Wed May 12 2020 John Doe <johndoe@artipie.org> - 0.1-2\n- Second artipie package"
+            ).author(),
             new IsEqual<>("John Doe <johndoe@artipie.org>")
         );
     }
@@ -54,15 +50,27 @@ class ChangelogEntryTest {
     void shouldParseDate() {
         final int unixtime = 1589328000;
         MatcherAssert.assertThat(
-            this.entry.date(),
+            new ChangelogEntry(
+                "* Wed May 13 2020 John Doe <johndoe@artipie.org> - 0.1-2\n- Second artipie package"
+            ).date(),
             new IsEqual<>(unixtime)
         );
     }
 
     @Test
+    void shouldFailParseBadDate() {
+        final ChangelogEntry entry = new ChangelogEntry(
+            "* Abc March 41 20 John Doe <johndoe@artipie.org> - 0.1-2\n- Second artipie package"
+        );
+        Assertions.assertThrows(IllegalStateException.class, entry::date);
+    }
+
+    @Test
     void shouldParseContent() {
         MatcherAssert.assertThat(
-            this.entry.content(),
+            new ChangelogEntry(
+                "* Wed May 14 2020 John Doe <johndoe@artipie.org> - 0.1-2\n- Second artipie package"
+            ).content(),
             new IsEqual<>("- 0.1-2\n- Second artipie package")
         );
     }

--- a/src/test/java/com/artipie/rpm/meta/ChangelogEntryTest.java
+++ b/src/test/java/com/artipie/rpm/meta/ChangelogEntryTest.java
@@ -50,6 +50,16 @@ class ChangelogEntryTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UseUnderscoresInNumericLiterals")
+    void shouldParseDate() {
+        final int unixtime = 1589328000;
+        MatcherAssert.assertThat(
+            this.entry.date(),
+            new IsEqual<>(unixtime)
+        );
+    }
+
+    @Test
     void shouldParseContent() {
         MatcherAssert.assertThat(
             this.entry.content(),


### PR DESCRIPTION
Part of #191 
Added `date` method to `ChangelogEntry` for parsing date from source string