### PR TITLE
#230 - temp dir for metadata

### DIFF
--- a/src/main/java/com/artipie/rpm/ModifiableRepository.java
+++ b/src/main/java/com/artipie/rpm/ModifiableRepository.java
@@ -69,14 +69,15 @@ public final class ModifiableRepository implements PackageOutput {
      * @param repomd Repomd
      * @param metadata Metadata files
      * @param digest Hashing algorithm
+     * @param tmp Temp dir to store metadata
      * @checkstyle ParameterNumberCheck (3 lines)
      */
     public ModifiableRepository(final List<String> existing, final XmlRepomd repomd,
-        final List<Metadata> metadata, final Digest digest) {
+        final List<Metadata> metadata, final Digest digest, final Path tmp) {
         this.existing = existing;
         this.metadata = metadata;
         this.digest = digest;
-        this.origin = new Repository(repomd, metadata, digest);
+        this.origin = new Repository(repomd, metadata, digest, tmp);
     }
 
     /**

--- a/src/main/java/com/artipie/rpm/Repository.java
+++ b/src/main/java/com/artipie/rpm/Repository.java
@@ -59,15 +59,24 @@ final class Repository implements PackageOutput {
     private final Digest digest;
 
     /**
+     * Temp dir to store metadata.
+     */
+    private final Path tmp;
+
+    /**
      * Ctor.
      * @param repomd Repomd XML
      * @param files Metadata files outputs
      * @param digest Digest algorithm
+     * @param tmp Temp dir to store metadata
+     * @checkstyle ParameterNumberCheck (3 lines)
      */
-    Repository(final XmlRepomd repomd, final List<Metadata> files, final Digest digest) {
+    Repository(final XmlRepomd repomd, final List<Metadata> files, final Digest digest,
+        final Path tmp) {
         this.repomd = repomd;
         this.metadata = files;
         this.digest = digest;
+        this.tmp = tmp;
     }
 
     /**
@@ -100,11 +109,10 @@ final class Repository implements PackageOutput {
      */
     public List<Path> save(final NamingPolicy naming) throws IOException {
         final List<Path> outs = this.metadata.stream()
-            .map(new UncheckedFunc<>(meta -> meta.save(naming, this.digest, this.repomd)))
+            .map(new UncheckedFunc<>(meta -> meta.save(naming, this.digest, this.repomd, this.tmp)))
             .collect(Collectors.toList());
         this.repomd.close();
-        final Path file = this.repomd.file();
-        outs.add(Files.move(file, file.getParent().resolve("repomd.xml")));
+        outs.add(Files.move(this.repomd.file(), this.tmp.resolve("repomd.xml")));
         Logger.info(this, "repomd.xml closed");
         return outs;
     }

--- a/src/main/java/com/artipie/rpm/Rpm.java
+++ b/src/main/java/com/artipie/rpm/Rpm.java
@@ -303,7 +303,7 @@ public final class Rpm {
      * @param path Metadata to move
      * @param prefix Repo prefix
      * @return Metadata
-     * @todo 240:30min After https://github.com/artipie/asto/issues/201 is fixed, use SubStorage in
+     * @todo #240:30min After https://github.com/artipie/asto/issues/201 is fixed, use SubStorage in
      *  this method and get gid of if-else statement inside flatMapCompletable.
      */
     private Single<Path> moveRepodataToStorage(final Storage local, final Path path,

--- a/src/main/java/com/artipie/rpm/Rpm.java
+++ b/src/main/java/com/artipie/rpm/Rpm.java
@@ -187,8 +187,10 @@ public final class Rpm {
      */
     public Completable batchUpdate(final Key prefix) {
         final Path tmpdir;
+        final Path metadir;
         try {
             tmpdir = Files.createTempDirectory("repo-");
+            metadir = Files.createTempDirectory("meta-");
         } catch (final IOException err) {
             throw new IllegalStateException("Failed to create temp dir", err);
         }
@@ -208,18 +210,21 @@ public final class Rpm {
                 }
             )
             .sequential().observeOn(Schedulers.io())
-            .reduceWith(this::repository, Repository::update)
+            .reduceWith(() -> this.repository(metadir), Repository::update)
             .doOnSuccess(rep -> Logger.info(this, "repository updated"))
             .doOnSuccess(Repository::close)
             .doOnSuccess(rep -> Logger.info(this, "repository closed"))
             .flatMapObservable(repo -> Observable.fromIterable(repo.save(this.naming)))
             .doOnNext(file -> Files.move(file, tmpdir.resolve(file.getFileName())))
-            .flatMapSingle(path -> this.moveRepodataToStorage(local, path))
-            .map(path -> String.format("repodata/%s", path.getFileName().toString()))
+            .flatMapSingle(path -> this.moveRepodataToStorage(local, path, prefix))
+            .map(path -> path.getFileName().toString())
             .toList().map(HashSet::new)
-            .flatMapCompletable(this::removeOldMetadata)
+            .flatMapCompletable(preserve -> this.removeOldMetadata(preserve, prefix))
             .doOnTerminate(
-                () -> Rpm.cleanup(tmpdir)
+                () -> {
+                    Rpm.cleanup(tmpdir);
+                    Rpm.cleanup(metadir);
+                }
             );
     }
 
@@ -230,8 +235,10 @@ public final class Rpm {
      */
     public Completable updateBatchIncrementally(final Key prefix) {
         final Path tmpdir;
+        final Path metadir;
         try {
             tmpdir = Files.createTempDirectory("repo-");
+            metadir = Files.createTempDirectory("meta-");
         } catch (final IOException err) {
             throw new IllegalStateException("Failed to create temp dir", err);
         }
@@ -248,7 +255,7 @@ public final class Rpm {
                             content -> new RxStorageWrapper(local).save(new Key.From(file), content)
                         );
                 }
-            ).andThen(Single.fromCallable(() -> this.mdfRepository(tmpdir)))
+            ).andThen(Single.fromCallable(() -> this.mdfRepository(tmpdir, metadir)))
             .flatMap(
                 repo -> this.filePackageFromRpm(prefix, tmpdir, local)
                     .parallel().runOn(Schedulers.io())
@@ -266,10 +273,10 @@ public final class Rpm {
                     file, tmpdir.resolve(file.getFileName()), StandardCopyOption.REPLACE_EXISTING
                 )
             )
-            .flatMapSingle(path -> this.moveRepodataToStorage(local, path))
-            .map(path -> String.format("repodata/%s", path.getFileName().toString()))
+            .flatMapSingle(path -> this.moveRepodataToStorage(local, path, prefix))
+            .map(path -> path.getFileName().toString())
             .toList().map(HashSet::new)
-            .flatMapCompletable(this::removeOldMetadata)
+            .flatMapCompletable(preserve -> this.removeOldMetadata(preserve, prefix))
             .doOnTerminate(
                 () -> Rpm.cleanup(tmpdir)
             );
@@ -278,12 +285,13 @@ public final class Rpm {
     /**
      * Removes old metadata.
      * @param preserve Metadata to keep
+     * @param prefix Repo prefix
      * @return Completable
      */
-    private Completable removeOldMetadata(final Set<String> preserve) {
-        return new RxStorageWrapper(this.storage).list(new Key.From("repodata"))
+    private Completable removeOldMetadata(final Set<String> preserve, final Key prefix) {
+        return new RxStorageWrapper(this.storage).list(new Key.From(prefix, "repodata"))
             .flatMapObservable(Observable::fromIterable)
-            .filter(item -> !preserve.contains(item.string()))
+            .filter(item -> !preserve.contains(Paths.get(item.string()).getFileName().toString()))
             .flatMapCompletable(
                 item -> new RxStorageWrapper(this.storage).delete(item)
             );
@@ -293,15 +301,25 @@ public final class Rpm {
      * Moves repodata to storage.
      * @param local Local storage
      * @param path Metadata to move
+     * @param prefix Repo prefix
      * @return Metadata
+     * @todo 240:30min After https://github.com/artipie/asto/issues/201 is fixed, use SubStorage in
+     *  this method and get gid of if-else statement inside flatMapCompletable.
      */
-    private Single<Path> moveRepodataToStorage(final Storage local, final Path path) {
+    private Single<Path> moveRepodataToStorage(final Storage local, final Path path,
+        final Key prefix) {
         return new RxStorageWrapper(local)
             .value(new Key.From(path.getFileName().toString()))
             .flatMapCompletable(
-                content1 -> new RxStorageWrapper(this.storage).save(
-                    new Key.From("repodata", path.getFileName().toString()), content1
-                )
+                content -> {
+                    final Key key;
+                    if (prefix.string().isEmpty()) {
+                        key = new Key.From("repodata", path.getFileName().toString());
+                    } else {
+                        key = new Key.From(prefix, "repodata", path.getFileName().toString());
+                    }
+                    return new RxStorageWrapper(this.storage).save(key, content);
+                }
             ).toSingleDefault(path);
     }
 
@@ -339,14 +357,16 @@ public final class Rpm {
         for (final Path item : Files.list(dir).collect(Collectors.toList())) {
             Files.delete(item);
         }
+        Files.delete(dir);
     }
 
     /**
      * Get repository for file updates.
+     * @param tmp Temp dir to store metadata
      * @return Repository
      * @throws IOException If IO Exception occurs.
      */
-    private Repository repository() throws IOException {
+    private Repository repository(final Path tmp) throws IOException {
         try {
             return new Repository(
                 Rpm.xmlRepomd(),
@@ -355,7 +375,8 @@ public final class Rpm {
                         item -> new MetadataFile(item, item.output().start())
                     )
                 ).collect(Collectors.toList()),
-                this.digest
+                this.digest,
+                tmp
             );
         } catch (final XMLStreamException ex) {
             throw new IOException(ex);
@@ -365,10 +386,12 @@ public final class Rpm {
     /**
      * Get modifiable repository for file updates.
      * @param dir Temp directory
+     * @param metadir Temp dir to store metadata
      * @return Repository
      * @throws IOException If IO Exception occurs.
      */
-    private ModifiableRepository mdfRepository(final Path dir) throws IOException {
+    private ModifiableRepository mdfRepository(final Path dir, final Path metadir)
+        throws IOException {
         try {
             final Map<String, Path> data = new HashMap<>();
             new XmlPackage.Stream(this.filelists).get().map(XmlPackage::filename)
@@ -393,7 +416,8 @@ public final class Rpm {
                             )
                     )
                 ).collect(Collectors.toList()),
-                this.digest
+                this.digest,
+                metadir
             );
         } catch (final XMLStreamException ex) {
             throw new IOException(ex);

--- a/src/main/java/com/artipie/rpm/pkg/Metadata.java
+++ b/src/main/java/com/artipie/rpm/pkg/Metadata.java
@@ -48,10 +48,12 @@ public interface Metadata extends PackageOutput {
      * @param naming Naming policy
      * @param digest Digest
      * @param repomd Repomd to update
+     * @param tmp Temp di for metafile
      * @return Gzip metadata file
      * @throws IOException On error
+     * @checkstyle ParameterNumberCheck (3 lines)
      */
-    Path save(NamingPolicy naming, Digest digest, XmlRepomd repomd)
+    Path save(NamingPolicy naming, Digest digest, XmlRepomd repomd, Path tmp)
         throws IOException;
 
     /**

--- a/src/main/java/com/artipie/rpm/pkg/MetadataFile.java
+++ b/src/main/java/com/artipie/rpm/pkg/MetadataFile.java
@@ -94,10 +94,11 @@ public final class MetadataFile implements Metadata {
     }
 
     @Override
-    public Path save(final NamingPolicy naming, final Digest digest, final XmlRepomd repomd)
-        throws IOException {
+    // @checkstyle ParameterNumberCheck (3 lines)
+    public Path save(final NamingPolicy naming, final Digest digest, final XmlRepomd repomd,
+        final Path tmp) throws IOException {
         final Path open = this.out.file();
-        Path gzip = Files.createTempFile(this.type.filename(), ".gz");
+        Path gzip = Files.createTempFile(tmp, this.type.filename(), ".gz");
         MetadataFile.gzip(open, gzip);
         gzip = Files.move(
             gzip,

--- a/src/main/java/com/artipie/rpm/pkg/ModifiableMetadata.java
+++ b/src/main/java/com/artipie/rpm/pkg/ModifiableMetadata.java
@@ -69,10 +69,11 @@ public final class ModifiableMetadata implements Metadata {
     }
 
     @Override
+    // @checkstyle ParameterNumberCheck (3 lines)
     public Path save(final NamingPolicy naming, final Digest digest,
-        final XmlRepomd repomd) throws IOException {
+        final XmlRepomd repomd, final Path tmp) throws IOException {
         Files.delete(this.old);
-        return this.origin.save(naming, digest, repomd);
+        return this.origin.save(naming, digest, repomd, tmp);
     }
 
     @Override

--- a/src/test/java/com/artipie/rpm/RpmTest.java
+++ b/src/test/java/com/artipie/rpm/RpmTest.java
@@ -28,10 +28,20 @@ import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.rpm.meta.XmlPackage;
 import com.jcabi.xml.XMLDocument;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import org.cactoos.Scalar;
+import org.cactoos.list.ListOf;
+import org.cactoos.list.Mapped;
+import org.cactoos.scalar.AndInThreads;
+import org.cactoos.scalar.Unchecked;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
@@ -40,6 +50,7 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link Rpm}.
  *
  * @since 0.9
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class RpmTest {
 
@@ -47,6 +58,49 @@ final class RpmTest {
      * Path of repomd.xml fil.
      */
     private static final String REPOMD = "repodata/repomd.xml";
+
+    /**
+     * Abc test rmp file.
+     */
+    private static final Path ABC =
+        Paths.get("src/test/resources-binary/abc-1.01-26.git20200127.fc32.ppc64le.rpm");
+
+    /**
+     * Libdeflt test rmp file.
+     */
+    private static final Path LIBDEFLT =
+        Paths.get("src/test/resources-binary/libdeflt1_0-2020.03.27-25.1.armv7hl.rpm");
+
+    @Test
+    void updatesDifferentReposSimultaneouslyTwice() throws Exception {
+        final Storage storage = new InMemoryStorage();
+        final Rpm repo =  new Rpm(
+            storage, StandardNamingPolicy.SHA1, Digest.SHA256, true
+        );
+        final List<String> keys = new ListOf<>("one", "two", "three");
+        final CountDownLatch latch = new CountDownLatch(keys.size());
+        final List<Scalar<Boolean>> tasks = new Mapped<>(
+            key -> new Unchecked<>(
+                () -> {
+                    RpmTest.putFilesInStorage(storage, new Key.From(key));
+                    latch.countDown();
+                    latch.await();
+                    repo.batchUpdate(new Key.From(key)).blockingAwait();
+                    return true;
+                }
+            ),
+            keys
+        );
+        new AndInThreads(tasks).value();
+        new AndInThreads(tasks).value();
+        keys.forEach(
+            key -> {
+                final Key res = new Key.From(key, "repodata");
+                RpmTest.metadataArePresent(storage, res);
+                RpmTest.repomdIsPresent(storage, res);
+            }
+        );
+    }
 
     @Test
     void doesntBrakeMetadataWhenInvalidPackageSent()
@@ -58,9 +112,7 @@ final class RpmTest {
         storage.save(
             new Key.From("oldfile.rpm"),
             new Content.From(
-                Files.readAllBytes(
-                    Paths.get("src/test/resources-binary/abc-1.01-26.git20200127.fc32.ppc64le.rpm")
-                )
+                Files.readAllBytes(RpmTest.ABC)
             )
         );
         repo.batchUpdate(Key.ROOT).blockingAwait();
@@ -78,6 +130,7 @@ final class RpmTest {
             )
         );
         repo.batchUpdate(Key.ROOT).blockingAwait();
+        RpmTest.metadataArePresent(storage, Key.ROOT);
         MatcherAssert.assertThat(
             countData(
                 new String(
@@ -97,5 +150,53 @@ final class RpmTest {
                 .xpath("count(/*[local-name()='repomd']/*[local-name()='data'])")
                 .get(0)
         );
+    }
+
+    /**
+     * Checks that metadata are present.
+     * @param storage Storage
+     * @param repo Repodata key
+     */
+    private static void metadataArePresent(final Storage storage, final Key repo) {
+        new XmlPackage.Stream(true).get().forEach(
+            item ->
+                MatcherAssert.assertThat(
+                    String.format("Metadata %s is present", item.filename()),
+                    storage.list(repo).join().stream()
+                        .map(Key::string).filter(str -> str.contains(item.filename())).count(),
+                    new IsEqual<>(1L)
+                )
+        );
+    }
+
+    /**
+     * Checks that repomd is present.
+     * @param storage Storage
+     * @param key Key
+     */
+    private static void repomdIsPresent(final Storage storage, final Key key) {
+        MatcherAssert.assertThat(
+            "Repomd is present",
+            storage.list(key).join().stream()
+                .map(Key::string).filter(str -> str.contains("repomd")).count(),
+            new IsEqual<>(1L)
+        );
+    }
+
+    /**
+     * Puts files into storage.
+     * @param storage Where to put
+     * @param key Repo key
+     * @throws IOException On error
+     */
+    private static void putFilesInStorage(final Storage storage, final Key key) throws IOException {
+        storage.save(
+            new Key.From(key, RpmTest.ABC.getFileName().toString()),
+            new Content.From(Files.readAllBytes(RpmTest.ABC))
+        ).join();
+        storage.save(
+            new Key.From(key, RpmTest.LIBDEFLT.getFileName().toString()),
+            new Content.From(Files.readAllBytes(RpmTest.LIBDEFLT))
+        ).join();
     }
 }

--- a/src/test/java/com/artipie/rpm/pkg/MetadataFileTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/MetadataFileTest.java
@@ -56,7 +56,8 @@ public final class MetadataFileTest {
             final String openhex = new FileChecksum(fake, Digest.SHA1).hex();
             final long size = Files.size(fake);
             final Path gzip = meta.save(
-                new NamingPolicy.HashPrefixed(Digest.SHA1), Digest.SHA1, repomd
+                new NamingPolicy.HashPrefixed(Digest.SHA1), Digest.SHA1,
+                repomd, Files.createDirectory(tmp.resolve("meta"))
             );
             repomd.close();
             final String hex = new FileChecksum(gzip, Digest.SHA1).hex();

--- a/src/test/java/com/artipie/rpm/pkg/ModifiableMetadataTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/ModifiableMetadataTest.java
@@ -110,7 +110,10 @@ class ModifiableMetadataTest {
         final Path repomd = temp.resolve("repomd.xml");
         try (XmlRepomd xml = new XmlRepomd(repomd)) {
             xml.begin(System.currentTimeMillis() / Tv.THOUSAND);
-            mtd.save(StandardNamingPolicy.PLAIN, Digest.SHA256, xml);
+            mtd.save(
+                StandardNamingPolicy.PLAIN, Digest.SHA256, xml,
+                Files.createDirectory(temp.resolve("meta"))
+            );
         }
         MatcherAssert.assertThat(
             new String(Files.readAllBytes(repomd), Charset.defaultCharset()),


### PR DESCRIPTION
Part of #230 - create temp dir for metadata on each update. Also, I've corrected old metadata clean up as it does not work on not `ROOT` repositories. 