### PR TITLE
Remove puzzle from XmlRepomd

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlRepomd.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlRepomd.java
@@ -37,15 +37,6 @@ import javax.xml.stream.XMLStreamWriter;
  * This object is not thread safe and depends on order of method calls.
  * </p>
  * @since 0.6
- * @todo #81:30min Refactor this class so it uses XmlFile instead of using
- *  a XMLStreamWriter and a Path. It is not straightforward because it exposes
- *  the Path via the path() which is now hidden in the XmlFile object.
- *  We must keep the path hidden there while at the same time allow for
- *  Repository to be responsible of triggering the save of the repomd file
- *  after all the metadata files (declared in Rpm) have wrote themselves to
- *  repomd as expected. One solution would be to delegate to the xml files
- *  and thus to XmlFile the act of moving itself in the desired place: in
- *  that case the way other metadata files are saved should be adapted.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class XmlRepomd implements Closeable {


### PR DESCRIPTION
Removed puzzle from `XmlRepomd` as it's not relevant anymore.