### PR TITLE
#278 - Extracted FilePackageHeader from FilePackage

### DIFF
--- a/src/main/java/com/artipie/rpm/pkg/FilePackageHeader.java
+++ b/src/main/java/com/artipie/rpm/pkg/FilePackageHeader.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.rpm.pkg;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.logging.Level;
+import org.redline_rpm.ReadableChannelWrapper;
+import org.redline_rpm.Scanner;
+import org.redline_rpm.header.Format;
+import org.redline_rpm.header.Header;
+
+/**
+ * Header of RPM package file.
+ *
+ * @since 0.11
+ */
+final class FilePackageHeader {
+
+    /**
+     * The RPM file.
+     */
+    private final Path file;
+
+    /**
+     * Ctor.
+     *
+     * @param file The RPM file.
+     */
+    FilePackageHeader(final Path file) {
+        this.file = file;
+    }
+
+    /**
+     * Get header.
+     *
+     * @return The header.
+     * @throws InvalidPackageException In case package is invalid.
+     * @throws IOException In case of I/O error.
+     */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    Header header() throws InvalidPackageException, IOException {
+        try (FileChannel chan = FileChannel.open(this.file, StandardOpenOption.READ)) {
+            final Format format;
+            try {
+                format = new Scanner(
+                    new PrintStream(Logger.stream(Level.FINE, this))
+                ).run(new ReadableChannelWrapper(chan));
+                // @checkstyle IllegalCatchCheck (1 line)
+            } catch (final RuntimeException ex) {
+                throw new InvalidPackageException(ex);
+            }
+            final Header header = format.getHeader();
+            Logger.debug(this, "header: %s", header.toString());
+            return header;
+        }
+    }
+}

--- a/src/main/java/com/artipie/rpm/pkg/FilePackageHeader.java
+++ b/src/main/java/com/artipie/rpm/pkg/FilePackageHeader.java
@@ -38,7 +38,7 @@ import org.redline_rpm.header.Header;
 /**
  * Header of RPM package file.
  *
- * @since 0.11
+ * @since 0.10
  */
 final class FilePackageHeader {
 

--- a/src/test/java/com/artipie/rpm/pkg/ModifiableMetadataTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/ModifiableMetadataTest.java
@@ -28,28 +28,19 @@ import com.artipie.rpm.StandardNamingPolicy;
 import com.artipie.rpm.meta.XmlPackage;
 import com.artipie.rpm.meta.XmlRepomd;
 import com.jcabi.aspects.Tv;
-import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.logging.Level;
 import javax.xml.stream.XMLStreamException;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsNot;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.redline_rpm.ReadableChannelWrapper;
-import org.redline_rpm.Scanner;
-import org.redline_rpm.header.Format;
-import org.redline_rpm.header.Header;
 
 /**
  * Test for {@link ModifiableMetadata}.
@@ -70,7 +61,9 @@ class ModifiableMetadataTest {
         );
         final Path rpm =
             Paths.get("src/test/resources-binary/abc-1.01-26.git20200127.fc32.ppc64le.rpm");
-        mtd.accept(new FilePackage.Headers(this.header(rpm), rpm, Digest.SHA256));
+        mtd.accept(
+            new FilePackage.Headers(new FilePackageHeader(rpm).header(), rpm, Digest.SHA256)
+        );
         mtd.close();
         mtd.brush(
             new ListOf<String>("7eaefd1cb4f9740558da7f12f9cb5a6141a47f5d064a98d46c29959869af1a44")
@@ -126,20 +119,4 @@ class ModifiableMetadataTest {
             )
         );
     }
-
-    /**
-     * Creates header from rpm file.
-     * @param file File
-     * @return Header
-     * @throws IOException On error
-     */
-    private Header header(final Path file) throws IOException {
-        try (FileChannel chan = FileChannel.open(file, StandardOpenOption.READ)) {
-            final Format format = new Scanner(
-                new PrintStream(Logger.stream(Level.FINE, this))
-            ).run(new ReadableChannelWrapper(chan));
-            return format.getHeader();
-        }
-    }
-
 }


### PR DESCRIPTION
Closes #278 
Extracted `FilePackageHeader` from `FilePackage`, added usage in tests to reduce code duplication