### PR TITLE
Default naming policy in config from yaml

### DIFF
--- a/src/main/java/com/artipie/rpm/RepoConfig.java
+++ b/src/main/java/com/artipie/rpm/RepoConfig.java
@@ -89,7 +89,7 @@ public interface RepoConfig {
         public NamingPolicy naming() {
             return Optional.ofNullable(this.yaml.string(RpmOptions.NAMING_POLICY.optionName()))
                 .map(naming -> StandardNamingPolicy.valueOf(naming.toUpperCase(Locale.US)))
-                .orElse(StandardNamingPolicy.PLAIN);
+                .orElse(StandardNamingPolicy.SHA256);
         }
 
         @Override

--- a/src/test/java/com/artipie/rpm/RepoConfigFromYamlTest.java
+++ b/src/test/java/com/artipie/rpm/RepoConfigFromYamlTest.java
@@ -58,7 +58,7 @@ public final class RepoConfigFromYamlTest {
             new RepoConfig.FromYaml(Optional.empty()),
             Matchers.allOf(
                 new MatcherOf<>(cnfg -> cnfg.digest() == Digest.SHA256),
-                new MatcherOf<>(cnfg -> cnfg.naming() == StandardNamingPolicy.PLAIN),
+                new MatcherOf<>(cnfg -> cnfg.naming() == StandardNamingPolicy.SHA256),
                 new MatcherOf<>(new ProcOf<>(RepoConfig.FromYaml::filelists))
             )
         );


### PR DESCRIPTION
I've set `sha256` as default naming policy in yaml configuration.