### PR TITLE
#299 - Improvements to PackagesCount

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/PackagesCount.java
+++ b/src/main/java/com/artipie/rpm/meta/PackagesCount.java
@@ -79,10 +79,11 @@ public class PackagesCount {
                 final Matcher matcher = ATTR.matcher(line);
                 if (matcher.find()) {
                     result = OptionalInt.of(Integer.parseInt(matcher.group(1)));
+                    break;
                 }
             }
             return result.orElseThrow(
-                () -> new IllegalStateException("Failed to find packages attribute")
+                () -> new IllegalArgumentException("Failed to find packages attribute")
             );
         }
     }

--- a/src/test/java/com/artipie/rpm/meta/PackagesCountTest.java
+++ b/src/test/java/com/artipie/rpm/meta/PackagesCountTest.java
@@ -23,10 +23,14 @@
  */
 package com.artipie.rpm.meta;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for {@link PackagesCount}.
@@ -43,5 +47,24 @@ class PackagesCountTest {
             ).value(),
             new IsEqual<>(2)
         );
+    }
+
+    @Test
+    void shouldFailIfAttributeIsMissing(final @TempDir Path dir) throws Exception {
+        final PackagesCount count = new PackagesCount(
+            Files.write(dir.resolve("empty.xml"), "".getBytes())
+        );
+        Assertions.assertThrows(IllegalArgumentException.class, count::value);
+    }
+
+    @Test
+    void shouldFailIfAttributeIsTooFarFromStart(final @TempDir Path dir) throws Exception {
+        final PackagesCount count = new PackagesCount(
+            Files.write(
+                dir.resolve("big.xml"),
+                "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n<metadata packages=\"123\"/>".getBytes()
+            )
+        );
+        Assertions.assertThrows(IllegalArgumentException.class, count::value);
     }
 }


### PR DESCRIPTION
Closes #299 
Improvements to `PackagesCount`:
- stop scanning the file if attribute has been found
- better exception when attribute is missing
- negative tests for cases when attribute is not found