### PR TITLE
#319 - added path() to TestRpm.java

### DIFF
--- a/src/test/java/com/artipie/rpm/RpmTest.java
+++ b/src/test/java/com/artipie/rpm/RpmTest.java
@@ -23,7 +23,6 @@
  */
 package com.artipie.rpm;
 
-import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.SubStorage;
@@ -110,9 +109,7 @@ final class RpmTest {
         final Rpm repo =  new Rpm(storage, StandardNamingPolicy.SHA1, Digest.SHA256, filelists);
         new TestRpm.Abc().put(storage);
         repo.batchUpdate(Key.ROOT).blockingAwait();
-        final byte[] broken = {0x00, 0x01, 0x02 };
-        storage.save(new Key.From("broken.rpm"), new Content.From(broken)).get();
-        new TestRpm.Libdeflt().put(storage);
+        new TestRpm.Multiple(new TestRpm.Invalid(), new TestRpm.Libdeflt()).put(storage);
         repo.batchUpdate(Key.ROOT).blockingAwait();
         MatcherAssert.assertThat(
             storage,
@@ -127,9 +124,7 @@ final class RpmTest {
         final Rpm repo =  new Rpm(storage, StandardNamingPolicy.SHA1, Digest.SHA256, filelists);
         new TestRpm.Libdeflt().put(storage);
         repo.batchUpdate(Key.ROOT).blockingAwait();
-        final byte[] broken = {0x00, 0x01, 0x02 };
-        storage.save(new Key.From("broken-file.rpm"), new Content.From(broken)).get();
-        new TestRpm.Abc().put(storage);
+        new TestRpm.Multiple(new TestRpm.Abc(), new TestRpm.Invalid()).put(storage);
         repo.batchUpdateIncrementally(Key.ROOT).blockingAwait();
         MatcherAssert.assertThat(
             storage,

--- a/src/test/java/com/artipie/rpm/TestRpm.java
+++ b/src/test/java/com/artipie/rpm/TestRpm.java
@@ -27,6 +27,7 @@ import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -150,10 +151,14 @@ public interface TestRpm {
          * @return Path
          */
         private static Path file(final String name) {
-            return Paths.get(
-                Thread.currentThread().getContextClassLoader()
-                    .getResource(name).getPath()
-            );
+            try {
+                return Paths.get(
+                    Thread.currentThread().getContextClassLoader()
+                        .getResource(name).toURI()
+                );
+            } catch (final URISyntaxException ex) {
+                throw new IllegalStateException("Failed to load test recourses", ex);
+            }
         }
     }
 

--- a/src/test/java/com/artipie/rpm/http/RpmUploadTest.java
+++ b/src/test/java/com/artipie/rpm/http/RpmUploadTest.java
@@ -32,11 +32,11 @@ import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.rpm.RepoConfig;
+import com.artipie.rpm.TestRpm;
 import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Map;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
@@ -55,9 +55,7 @@ public class RpmUploadTest {
     @Test
     void canUploadArtifact() throws Exception {
         final Storage storage = new InMemoryStorage();
-        final byte[] content = Files.readAllBytes(
-            Paths.get("src/test/resources-binary/abc-1.01-26.git20200127.fc32.ppc64le.rpm")
-        );
+        final byte[] content = Files.readAllBytes(new TestRpm.Abc().path());
         MatcherAssert.assertThat(
             "ACCEPTED 202 returned",
             new RpmUpload(storage, new RepoConfig.Simple()).response(
@@ -124,9 +122,7 @@ public class RpmUploadTest {
     @Test
     void skipsUpdate() throws Exception {
         final Storage storage = new InMemoryStorage();
-        final byte[] content = Files.readAllBytes(
-            Paths.get("src/test/resources-binary/abc-1.01-26.git20200127.fc32.ppc64le.rpm")
-        );
+        final byte[] content = Files.readAllBytes(new TestRpm.Abc().path());
         MatcherAssert.assertThat(
             "ACCEPTED 202 returned",
             new RpmUpload(storage, new RepoConfig.Simple()).response(

--- a/src/test/java/com/artipie/rpm/pkg/FilePackageTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/FilePackageTest.java
@@ -54,9 +54,7 @@ class FilePackageTest {
     @Test
     void returnsParsedFile() throws IOException {
         MatcherAssert.assertThat(
-            new FilePackage(
-                Paths.get("src/test/resources-binary/abc-1.01-26.git20200127.fc32.ppc64le.rpm")
-            ).parsed(),
+            new FilePackage(new TestRpm.Abc().path()).parsed(),
             new IsInstanceOf(ParsedFilePackage.class)
         );
     }
@@ -91,10 +89,7 @@ class FilePackageTest {
     @Test
     void onSaveCallsAcceptAndDeletesFile(@TempDir final Path temp) throws IOException {
         final Path rpm = temp.resolve("test.rpm");
-        Files.copy(
-            Paths.get("src/test/resources-binary/libdeflt1_0-2020.03.27-25.1.armv7hl.rpm"),
-            rpm
-        );
+        Files.copy(new TestRpm.Libdeflt().path(), rpm);
         final PackageOutput.FileOutput.Fake out =
             new PackageOutput.FileOutput.Fake(temp.resolve("any"));
         new FilePackage(rpm).save(out, Digest.SHA256);

--- a/src/test/java/com/artipie/rpm/pkg/ModifiableMetadataTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/ModifiableMetadataTest.java
@@ -25,6 +25,7 @@ package com.artipie.rpm.pkg;
 
 import com.artipie.rpm.Digest;
 import com.artipie.rpm.StandardNamingPolicy;
+import com.artipie.rpm.TestRpm;
 import com.artipie.rpm.hm.NodeHasPkgCount;
 import com.artipie.rpm.meta.XmlPackage;
 import com.artipie.rpm.meta.XmlRepomd;
@@ -62,8 +63,7 @@ class ModifiableMetadataTest {
             new MetadataFile(XmlPackage.PRIMARY, new PrimaryOutput(res).start()),
             part
         );
-        final Path rpm =
-            Paths.get("src/test/resources-binary/abc-1.01-26.git20200127.fc32.ppc64le.rpm");
+        final Path rpm = new TestRpm.Abc().path();
         mtd.accept(
             new FilePackage.Headers(new FilePackageHeader(rpm).header(), rpm, Digest.SHA256)
         );

--- a/src/test/java/com/artipie/rpm/pkg/PrimaryOutputTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/PrimaryOutputTest.java
@@ -24,6 +24,7 @@
 package com.artipie.rpm.pkg;
 
 import com.artipie.rpm.Digest;
+import com.artipie.rpm.TestRpm;
 import com.artipie.rpm.meta.XmlPrimaryMaid;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -48,8 +49,7 @@ class PrimaryOutputTest {
         final Path res = temp.resolve("primary.xml");
         try (PackageOutput.FileOutput primary = new PrimaryOutput(res)) {
             primary.start();
-            final Path rpm =
-                Paths.get("src/test/resources-binary/abc-1.01-26.git20200127.fc32.ppc64le.rpm");
+            final Path rpm = new TestRpm.Abc().path();
             primary.accept(
                 new FilePackage.Headers(new FilePackageHeader(rpm).header(), rpm, Digest.SHA256)
             );
@@ -102,8 +102,7 @@ class PrimaryOutputTest {
         final Path res = temp.resolve("primary.xml");
         try (PackageOutput.FileOutput primary = new PrimaryOutput(res)) {
             primary.start();
-            final Path rpm =
-                Paths.get("src/test/resources-binary/libdeflt1_0-2020.03.27-25.1.armv7hl.rpm");
+            final Path rpm = new TestRpm.Libdeflt().path();
             primary.accept(
                 new FilePackage.Headers(new FilePackageHeader(rpm).header(), rpm, Digest.SHA256)
             );


### PR DESCRIPTION
Part of #319 - added `path()` method to `TestRpm` and used it instead of `Paths.get()`. Also corrected `RpmTest` to use `TestRpm.Invalid()`. 