### PR TITLE
#333 - use PublisherAs and KeyLastPart from asto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.23.2</version>
+      <version>0.23.3</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
Updated asto and used `PublisherAs` and `KeyLastPart` from the new version to close #333.