### PR TITLE
#250 - use substorage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.artipie</groupId>
     <artifactId>ppom</artifactId>
-    <version>0.3.8</version>
+    <version>0.3.4</version>
   </parent>
   <artifactId>rpm-adapter</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.artipie</groupId>
     <artifactId>ppom</artifactId>
-    <version>0.3.6</version>
+    <version>0.3.8</version>
   </parent>
   <artifactId>rpm-adapter</artifactId>
   <version>1.0-SNAPSHOT</version>


### PR DESCRIPTION
Simplified `Rpm#moveRepodataToStorage` to use `SubStorage` instead of `Key` with prefix to close #250.