### PR TITLE
#323 - use XmlException for errors with xml metadata

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlException.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlException.java
@@ -51,7 +51,7 @@ public final class XmlException extends RuntimeException {
      * @param message Message
      * @param cause Error cause
      */
-    XmlException(final String message, final Throwable cause) {
+    public XmlException(final String message, final Throwable cause) {
         super(message, cause);
     }
 

--- a/src/main/java/com/artipie/rpm/meta/XmlMaid.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlMaid.java
@@ -95,7 +95,7 @@ public interface XmlMaid {
                     reader.close();
                 }
             } catch (final XMLStreamException ex) {
-                throw new IOException(ex);
+                throw new XmlException(ex);
             }
             Files.move(tmp, this.file, StandardCopyOption.REPLACE_EXISTING);
             return res;

--- a/src/main/java/com/artipie/rpm/pkg/FilelistsOutput.java
+++ b/src/main/java/com/artipie/rpm/pkg/FilelistsOutput.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.rpm.pkg;
 
+import com.artipie.rpm.meta.XmlException;
 import com.artipie.rpm.meta.XmlFilelists;
 import com.artipie.rpm.meta.XmlMaid;
 import com.artipie.rpm.meta.XmlPackage;
@@ -70,11 +71,11 @@ public final class FilelistsOutput implements PackageOutput.FileOutput {
      * @return Self
      * @throws IOException On failure
      */
-    public FilelistsOutput start() throws IOException {
+    public FilelistsOutput start() {
         try {
             this.xml.startPackages();
         } catch (final XMLStreamException err) {
-            throw new IOException("Failed to start packages", err);
+            throw new XmlException("Failed to start packages", err);
         }
         return this;
     }
@@ -92,7 +93,7 @@ public final class FilelistsOutput implements PackageOutput.FileOutput {
                     tags.dirIndexes()
                 ).close();
         } catch (final XMLStreamException err) {
-            throw new IOException("Failed to add package", err);
+            throw new XmlException("Failed to add package", err);
         }
     }
 

--- a/src/main/java/com/artipie/rpm/pkg/MetadataFile.java
+++ b/src/main/java/com/artipie/rpm/pkg/MetadataFile.java
@@ -26,6 +26,7 @@ package com.artipie.rpm.pkg;
 import com.artipie.rpm.Digest;
 import com.artipie.rpm.FileChecksum;
 import com.artipie.rpm.meta.XmlAlter;
+import com.artipie.rpm.meta.XmlException;
 import com.artipie.rpm.meta.XmlPackage;
 import com.artipie.rpm.meta.XmlRepomd;
 import com.jcabi.log.Logger;
@@ -107,7 +108,7 @@ public final class MetadataFile implements Metadata {
             data.gzipSize(Files.size(gzip));
             data.openSize(Files.size(open));
         } catch (final XMLStreamException err) {
-            throw new IOException("Failed to update repomd.xml", err);
+            throw new XmlException("Failed to update repomd.xml", err);
         }
         Files.delete(open);
         return gzip;

--- a/src/main/java/com/artipie/rpm/pkg/OthersOutput.java
+++ b/src/main/java/com/artipie/rpm/pkg/OthersOutput.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.rpm.pkg;
 
+import com.artipie.rpm.meta.XmlException;
 import com.artipie.rpm.meta.XmlMaid;
 import com.artipie.rpm.meta.XmlOthers;
 import com.artipie.rpm.meta.XmlPackage;
@@ -68,13 +69,12 @@ public final class OthersOutput implements PackageOutput.FileOutput {
     /**
      * Starts processing of RPMs.
      * @return Self
-     * @throws IOException On error
      */
-    public OthersOutput start() throws IOException {
+    public OthersOutput start() {
         try {
             this.xml.startPackages();
         } catch (final XMLStreamException err) {
-            throw new IOException("Failed to start packages", err);
+            throw new XmlException("Failed to start packages", err);
         }
         return this;
     }
@@ -89,7 +89,7 @@ public final class OthersOutput implements PackageOutput.FileOutput {
             ).version(tags.epoch(), tags.version(), tags.release())
                 .changelog(tags.changelog()).close();
         } catch (final XMLStreamException err) {
-            throw new IOException("Failed to add package", err);
+            throw new XmlException("Failed to add package", err);
         }
     }
 

--- a/src/main/java/com/artipie/rpm/pkg/PrimaryOutput.java
+++ b/src/main/java/com/artipie/rpm/pkg/PrimaryOutput.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.rpm.pkg;
 
+import com.artipie.rpm.meta.XmlException;
 import com.artipie.rpm.meta.XmlMaid;
 import com.artipie.rpm.meta.XmlPackage;
 import com.artipie.rpm.meta.XmlPrimary;
@@ -69,13 +70,12 @@ public final class PrimaryOutput implements PackageOutput.FileOutput {
     /**
      * Starts processing of RPMs.
      * @return Self
-     * @throws IOException On errors
      */
-    public PrimaryOutput start() throws IOException {
+    public PrimaryOutput start() {
         try {
             this.xml.startPackages();
         } catch (final XMLStreamException err) {
-            throw new IOException("Failed to start packages", err);
+            throw new XmlException("Failed to start packages", err);
         }
         return this;
     }
@@ -114,7 +114,7 @@ public final class PrimaryOutput implements PackageOutput.FileOutput {
                     tags.dirIndexes()
                 ).close();
         } catch (final XMLStreamException err) {
-            throw new IOException("Failed to update XML", err);
+            throw new XmlException("Failed to update XML", err);
         }
     }
 

--- a/src/test/java/com/artipie/rpm/meta/XmlStreamJoin.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlStreamJoin.java
@@ -74,7 +74,7 @@ public final class XmlStreamJoin {
             writer.close();
         } catch (final XMLStreamException ex) {
             Files.delete(res);
-            throw new IOException(ex);
+            throw new XmlException(ex);
         }
         Files.move(res, target, StandardCopyOption.REPLACE_EXISTING);
     }


### PR DESCRIPTION
Closes #323 
Used `XmlException` for any problems with xml metadata instead of `IOException` 