### PR TITLE
#376 - added subdirs to location in primary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.28</version>
+      <version>0.33.1</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/com/artipie/rpm/Rpm.java
+++ b/src/main/java/com/artipie/rpm/Rpm.java
@@ -343,12 +343,16 @@ public final class Rpm {
             .filter(key -> key.string().endsWith(".rpm"))
             .flatMapSingle(
                 key -> {
-                    final String file = new KeyLastPart(key).get();
                     return new RxStorageWrapper(this.storage)
                         .value(key)
                         .flatMapCompletable(
-                            content -> new RxStorageWrapper(local).save(new Key.From(file), content)
-                        ).andThen(Single.fromCallable(() -> new FilePackage(tmpdir.resolve(file))));
+                            content -> new RxStorageWrapper(local)
+                                .save(new Key.From(key.string()), content)
+                        ).andThen(
+                            Single.fromCallable(
+                                () -> new FilePackage(tmpdir.resolve(key.string()), key.string())
+                            )
+                        );
                 }
             );
     }

--- a/src/main/java/com/artipie/rpm/pkg/FilePackage.java
+++ b/src/main/java/com/artipie/rpm/pkg/FilePackage.java
@@ -48,11 +48,18 @@ public final class FilePackage implements Package {
     private final Path file;
 
     /**
+     * The RPM file location relatively to the updated repository.
+     */
+    private final String location;
+
+    /**
      * Ctor.
      * @param path The path
+     * @param location File relative location
      */
-    public FilePackage(final Path path) {
+    public FilePackage(final Path path, final String location) {
         this.file = path;
+        this.location = location;
     }
 
     /**
@@ -66,7 +73,9 @@ public final class FilePackage implements Package {
     @Override
     public void save(final PackageOutput out, final Digest digest) throws IOException {
         out.accept(
-            new FilePackage.Headers(new FilePackageHeader(this.file).header(), this.file, digest)
+            new FilePackage.Headers(
+                new FilePackageHeader(this.file).header(), this.file, digest, this.location
+            )
         );
         Files.delete(this.file);
     }
@@ -83,7 +92,9 @@ public final class FilePackage implements Package {
      * @throws IOException On error
      */
     public Package parsed() throws InvalidPackageException, IOException {
-        return new ParsedFilePackage(new FilePackageHeader(this.file).header(), this.file);
+        return new ParsedFilePackage(
+            new FilePackageHeader(this.file).header(), this.file, this.location
+        );
     }
 
     /**
@@ -108,15 +119,33 @@ public final class FilePackage implements Package {
         private final Digest digest;
 
         /**
+         * The RPM file location relatively to the updated repository.
+         */
+        private final String location;
+
+        /**
          * Ctor.
+         * @param hdr Native headers
+         * @param file File path
+         * @param digest Digest
+         * @param location File relative location
+         * @checkstyle ParameterNumberCheck (10 lines)
+         */
+        Headers(final Header hdr, final Path file, final Digest digest, final String location) {
+            this.hdr = hdr;
+            this.file = file;
+            this.digest = digest;
+            this.location = location;
+        }
+
+        /**
+         * Ctor for tests.
          * @param hdr Native headers
          * @param file File path
          * @param digest Digest
          */
         Headers(final Header hdr, final Path file, final Digest digest) {
-            this.hdr = hdr;
-            this.file = file;
-            this.digest = digest;
+            this(hdr, file, digest, file.getFileName().toString());
         }
 
         @Override
@@ -136,7 +165,7 @@ public final class FilePackage implements Package {
 
         @Override
         public String href() {
-            return this.file.getFileName().toString();
+            return this.location;
         }
 
         @Override

--- a/src/main/java/com/artipie/rpm/pkg/ParsedFilePackage.java
+++ b/src/main/java/com/artipie/rpm/pkg/ParsedFilePackage.java
@@ -46,18 +46,25 @@ final class ParsedFilePackage implements Package {
     private final Path file;
 
     /**
+     * The RPM file location relatively to the updated repository.
+     */
+    private final String location;
+
+    /**
      * Ctor.
      * @param meta Package metadata
      * @param file File path
+     * @param location File relative location
      */
-    ParsedFilePackage(final Header meta, final Path file) {
+    ParsedFilePackage(final Header meta, final Path file, final String location) {
         this.header = meta;
         this.file = file;
+        this.location = location;
     }
 
     @Override
     public void save(final PackageOutput out, final Digest digest) throws IOException {
         Logger.debug(this, "accepting %s", this.file.getFileName());
-        out.accept(new FilePackage.Headers(this.header, this.file, digest));
+        out.accept(new FilePackage.Headers(this.header, this.file, digest, this.location));
     }
 }

--- a/src/test/java/com/artipie/rpm/pkg/FilePackageHeadersTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/FilePackageHeadersTest.java
@@ -27,6 +27,7 @@ import com.artipie.rpm.Digest;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -40,6 +41,7 @@ import org.redline_rpm.header.Header;
  *
  * @since 0.6.3
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class FilePackageHeadersTest {
 
     @Test
@@ -50,7 +52,7 @@ public final class FilePackageHeadersTest {
         header.createEntry(tag, expected);
         MatcherAssert.assertThat(
             new FilePackage.Headers(
-                header, unused, Digest.SHA256
+                header, unused, Digest.SHA256, "unused"
             ).header(tag).asString("default value"),
             new IsEqual<>(expected)
         );
@@ -64,7 +66,7 @@ public final class FilePackageHeadersTest {
         header.createEntry(tag, expected);
         MatcherAssert.assertThat(
             new FilePackage.Headers(
-                header, unused, Digest.SHA256
+                header, unused, Digest.SHA256, "unused"
             ).header(tag).asStrings(),
             new IsEqual<>(Arrays.asList(expected))
         );
@@ -78,7 +80,7 @@ public final class FilePackageHeadersTest {
         header.createEntry(tag, expected);
         MatcherAssert.assertThat(
             new FilePackage.Headers(
-                header, unused, Digest.SHA256
+                header, unused, Digest.SHA256, "unused"
             ).header(tag).asInt(0),
             new IsEqual<>(expected)
         );
@@ -92,7 +94,7 @@ public final class FilePackageHeadersTest {
         header.createEntry(tag, expected);
         MatcherAssert.assertThat(
             new FilePackage.Headers(
-                header, unused, Digest.SHA256
+                header, unused, Digest.SHA256, "unused"
             ).header(tag).asInts(),
             new IsEqual<>(expected)
         );
@@ -103,7 +105,7 @@ public final class FilePackageHeadersTest {
         final String expected = "default string value";
         MatcherAssert.assertThat(
             new FilePackage.Headers(
-                new Header(), unused, Digest.SHA256
+                new Header(), unused, Digest.SHA256, "unused"
             ).header(Header.HeaderTag.NAME).asString(expected),
             new IsEqual<>(expected)
         );
@@ -114,7 +116,7 @@ public final class FilePackageHeadersTest {
         final int expected = 0;
         MatcherAssert.assertThat(
             new FilePackage.Headers(
-                new Header(), unused, Digest.SHA256
+                new Header(), unused, Digest.SHA256, "unused"
             ).header(Header.HeaderTag.EPOCH).asInt(expected),
             new IsEqual<>(expected)
         );
@@ -124,13 +126,25 @@ public final class FilePackageHeadersTest {
     public void failParseInvalidPackageFile(@TempDir final Path tmp) throws Exception {
         final Path invalid = tmp.resolve("invalid.rpm");
         Files.write(invalid, "invalid".getBytes());
-        final FilePackage pack = new FilePackage(invalid);
+        final FilePackage pack = new FilePackage(invalid, "invalid");
         Assertions.assertThrows(InvalidPackageException.class, pack::parsed);
     }
 
     @Test
     public void failParseNotExistingPackageFile(@TempDir final Path tmp) {
-        final FilePackage pack = new FilePackage(tmp.resolve("not-exists.rpm"));
+        final String fake = "not-exists.rpm";
+        final FilePackage pack = new FilePackage(tmp.resolve(fake), fake);
         Assertions.assertThrows(IOException.class, pack::parsed);
+    }
+
+    @Test
+    public void returnsProvidedLocation() {
+        final String location = "subdir/some.rpm";
+        MatcherAssert.assertThat(
+            new FilePackage.Headers(
+                new Header(), Paths.get("unused"), Digest.SHA256, location
+            ).href(),
+            new IsEqual<>(location)
+        );
     }
 }

--- a/src/test/java/com/artipie/rpm/pkg/FilePackageTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/FilePackageTest.java
@@ -46,15 +46,16 @@ class FilePackageTest {
     void returnsPath() {
         final Path path = Paths.get("some/path/package.rpm");
         MatcherAssert.assertThat(
-            new FilePackage(path).path(),
+            new FilePackage(path, path.getFileName().toString()).path(),
             new IsEqual<>(path)
         );
     }
 
     @Test
     void returnsParsedFile() throws IOException {
+        final Path path = new TestRpm.Abc().path();
         MatcherAssert.assertThat(
-            new FilePackage(new TestRpm.Abc().path()).parsed(),
+            new FilePackage(path, path.getFileName().toString()).parsed(),
             new IsInstanceOf(ParsedFilePackage.class)
         );
     }
@@ -63,7 +64,7 @@ class FilePackageTest {
     void throwsExceptionIfFileDoesNotExists() {
         Assertions.assertThrows(
             IOException.class,
-            () -> new FilePackage(Paths.get("some/file")).parsed()
+            () -> new FilePackage(Paths.get("some/file"), "file").parsed()
         );
     }
 
@@ -73,7 +74,7 @@ class FilePackageTest {
         Files.write(rpm, new TestRpm.Invalid().bytes());
         Assertions.assertThrows(
             InvalidPackageException.class,
-            () -> new FilePackage(rpm).parsed()
+            () -> new FilePackage(rpm, rpm.getFileName().toString()).parsed()
         );
     }
 
@@ -81,7 +82,7 @@ class FilePackageTest {
     void canPresentItselfAsString() {
         final String name = "package.rpm";
         MatcherAssert.assertThat(
-            new FilePackage(Paths.get("urs/some_dir/", name)).toString(),
+            new FilePackage(Paths.get("urs/some_dir/", name), name).toString(),
             new IsEqual<>(String.format("FilePackage[%s]", name))
         );
     }
@@ -92,7 +93,7 @@ class FilePackageTest {
         Files.copy(new TestRpm.Libdeflt().path(), rpm);
         final PackageOutput.FileOutput.Fake out =
             new PackageOutput.FileOutput.Fake(temp.resolve("any"));
-        new FilePackage(rpm).save(out, Digest.SHA256);
+        new FilePackage(rpm, rpm.getFileName().toString()).save(out, Digest.SHA256);
         MatcherAssert.assertThat(
             "PackageOutput was accepted",
             out.isAccepted(),

--- a/src/test/java/com/artipie/rpm/pkg/OthersOutputTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/OthersOutputTest.java
@@ -50,7 +50,10 @@ class OthersOutputTest {
             others.start();
             final Path rpm = abc.path();
             others.accept(
-                new FilePackage.Headers(new FilePackageHeader(rpm).header(), rpm, Digest.SHA256)
+                new FilePackage.Headers(
+                    new FilePackageHeader(rpm).header(), rpm,
+                    Digest.SHA256, rpm.getFileName().toString()
+                )
             );
         }
         MatcherAssert.assertThat(
@@ -96,7 +99,10 @@ class OthersOutputTest {
             others.start();
             final Path rpm = libdeflt.path();
             others.accept(
-                new FilePackage.Headers(new FilePackageHeader(rpm).header(), rpm, Digest.SHA256)
+                new FilePackage.Headers(
+                    new FilePackageHeader(rpm).header(), rpm,
+                    Digest.SHA256, rpm.getFileName().toString()
+                )
             );
         }
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/rpm/pkg/PrimaryOutputTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/PrimaryOutputTest.java
@@ -51,7 +51,10 @@ class PrimaryOutputTest {
             primary.start();
             final Path rpm = new TestRpm.Abc().path();
             primary.accept(
-                new FilePackage.Headers(new FilePackageHeader(rpm).header(), rpm, Digest.SHA256)
+                new FilePackage.Headers(
+                    new FilePackageHeader(rpm).header(), rpm,
+                    Digest.SHA256, rpm.getFileName().toString()
+                )
             );
         }
         MatcherAssert.assertThat(
@@ -102,7 +105,10 @@ class PrimaryOutputTest {
             primary.start();
             final Path rpm = new TestRpm.Libdeflt().path();
             primary.accept(
-                new FilePackage.Headers(new FilePackageHeader(rpm).header(), rpm, Digest.SHA256)
+                new FilePackage.Headers(
+                    new FilePackageHeader(rpm).header(), rpm,
+                    Digest.SHA256, rpm.getFileName().toString()
+                )
             );
         }
         MatcherAssert.assertThat(


### PR DESCRIPTION
Part of #376 
Fixed `location` tag in `primary.xml` by providing storage key of the rpm package to headers.