### PR TITLE
#376 - Take not root keys into account

### DIFF
--- a/src/main/java/com/artipie/rpm/Rpm.java
+++ b/src/main/java/com/artipie/rpm/Rpm.java
@@ -343,14 +343,21 @@ public final class Rpm {
             .filter(key -> key.string().endsWith(".rpm"))
             .flatMapSingle(
                 key -> {
+                    final String filename;
+                    if (key.equals(prefix)) {
+                        filename = key.string();
+                    } else {
+                        filename = key.string().replaceFirst(prefix.string(), "")
+                            .replaceFirst("^/", "");
+                    }
                     return new RxStorageWrapper(this.storage)
                         .value(key)
                         .flatMapCompletable(
                             content -> new RxStorageWrapper(local)
-                                .save(new Key.From(key.string()), content)
+                                .save(new Key.From(filename), content)
                         ).andThen(
                             Single.fromCallable(
-                                () -> new FilePackage(tmpdir.resolve(key.string()), key.string())
+                                () -> new FilePackage(tmpdir.resolve(filename), filename)
                             )
                         );
                 }


### PR DESCRIPTION
Closes #376 
Take not root keys into account: when we update rpm repo not by ROOT key (let's call it prefix) and list items from the storage by this prefix, items key includes this prefix which we have to cut from the location as location path should be relative to this prefix.