### PR TITLE
Faster xml event reader and skeleton for new sdk API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@ SOFTWARE.
                     <limit>
                       <counter>CLASS</counter>
                       <value>MISSEDCOUNT</value>
-                      <maximum>4</maximum>
+                      <maximum>5</maximum>
                     </limit>
                   </limits>
                 </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@ SOFTWARE.
       <version>1.8.0-alpha2</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml</groupId>
+      <artifactId>aalto-xml</artifactId>
+      <version>1.2.2</version>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <scope>runtime</scope>

--- a/src/main/java/com/artipie/rpm/RpmMetadata.java
+++ b/src/main/java/com/artipie/rpm/RpmMetadata.java
@@ -1,0 +1,129 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.rpm;
+
+import com.artipie.rpm.meta.XmlPackage;
+import com.artipie.rpm.pkg.FilePackage;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
+
+/**
+ * Rpm metadata class works with xml metadata - adds or removes records about xml packages.
+ * @since 1.4
+ */
+public interface RpmMetadata {
+
+    /**
+     * Removes RMP records from metadata.
+     * @since 1.4
+     */
+    final class Remove {
+
+        /**
+         * Metadata list.
+         */
+        private final List<MetadataItem> items;
+
+        /**
+         * Ctor.
+         * @param items Metadata items
+         */
+        public Remove(final MetadataItem... items) {
+            this.items = Arrays.asList(items);
+        }
+
+        /**
+         * Removes records from metadata by RPMs checksums.
+         * @param checksums Rpms checksums  to remove by
+         */
+        public void perform(final List<String> checksums) {
+            throw new NotImplementedException("Will be implemented later");
+        }
+    }
+
+    /**
+     * Appends RMP records into metadata.
+     * @since 1.4
+     */
+    final class Append {
+
+        /**
+         * Metadata list.
+         */
+        private final List<MetadataItem> items;
+
+        /**
+         * Ctor.
+         * @param items Metadata items
+         */
+        public Append(final MetadataItem... items) {
+            this.items = Arrays.asList(items);
+        }
+
+        /**
+         * Appends records about provided RPMs.
+         * @param packages Rpms to append info about
+         */
+        public void perform(final List<FilePackage> packages) {
+            throw new NotImplementedException("Not implemented yet");
+        }
+    }
+
+    /**
+     * Metadata item.
+     * @since 1.4
+     */
+    final class MetadataItem {
+
+        /**
+         * Xml metadata type.
+         */
+        private final XmlPackage type;
+
+        /**
+         * Xml metadata input stream.
+         */
+        private final InputStream input;
+
+        /**
+         * Xml metadata output, where write the result.
+         */
+        private final OutputStream out;
+
+        /**
+         * Ctor.
+         * @param type Xml type
+         * @param input Xml metadata input stream
+         * @param out Xml metadata output, where write the result
+         */
+        MetadataItem(final XmlPackage type, final InputStream input, final OutputStream out) {
+            this.type = type;
+            this.input = input;
+            this.out = out;
+        }
+    }
+}

--- a/src/main/java/com/artipie/rpm/RpmMetadata.java
+++ b/src/main/java/com/artipie/rpm/RpmMetadata.java
@@ -28,6 +28,7 @@ import com.artipie.rpm.pkg.FilePackage;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.apache.commons.lang3.NotImplementedException;
 
@@ -46,7 +47,7 @@ public interface RpmMetadata {
         /**
          * Metadata list.
          */
-        private final List<MetadataItem> items;
+        private final Collection<MetadataItem> items;
 
         /**
          * Ctor.
@@ -74,7 +75,7 @@ public interface RpmMetadata {
         /**
          * Metadata list.
          */
-        private final List<MetadataItem> items;
+        private final Collection<MetadataItem> items;
 
         /**
          * Ctor.

--- a/src/main/java/com/artipie/rpm/RpmMetadata.java
+++ b/src/main/java/com/artipie/rpm/RpmMetadata.java
@@ -29,7 +29,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import org.apache.commons.lang3.NotImplementedException;
 
 /**
@@ -61,7 +60,7 @@ public interface RpmMetadata {
          * Removes records from metadata by RPMs checksums.
          * @param checksums Rpms checksums  to remove by
          */
-        public void perform(final List<String> checksums) {
+        public void perform(final Collection<String> checksums) {
             throw new NotImplementedException("Will be implemented later");
         }
     }
@@ -89,7 +88,7 @@ public interface RpmMetadata {
          * Appends records about provided RPMs.
          * @param packages Rpms to append info about
          */
-        public void perform(final List<FilePackage> packages) {
+        public void perform(final Collection<FilePackage> packages) {
             throw new NotImplementedException("Not implemented yet");
         }
     }

--- a/src/main/java/com/artipie/rpm/meta/XmlMaid.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlMaid.java
@@ -23,6 +23,8 @@
  */
 package com.artipie.rpm.meta;
 
+import com.fasterxml.aalto.stax.InputFactoryImpl;
+import com.fasterxml.aalto.stax.OutputFactoryImpl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -33,8 +35,6 @@ import java.util.List;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLEventWriter;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 
@@ -84,10 +84,8 @@ public interface XmlMaid {
             final long res;
             try (InputStream in = Files.newInputStream(this.file);
                 OutputStream out = Files.newOutputStream(tmp)) {
-                final XMLEventReader reader =
-                    XMLInputFactory.newInstance().createXMLEventReader(in);
-                final XMLEventWriter writer =
-                    XMLOutputFactory.newInstance().createXMLEventWriter(out);
+                final XMLEventReader reader = new InputFactoryImpl().createXMLEventReader(in);
+                final XMLEventWriter writer = new OutputFactoryImpl().createXMLEventWriter(out);
                 try {
                     res = ByPkgidAttr.process(ids, reader, writer);
                 } finally {

--- a/src/main/java/com/artipie/rpm/meta/XmlPrimaryMaid.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlPrimaryMaid.java
@@ -23,6 +23,8 @@
  */
 package com.artipie.rpm.meta;
 
+import com.fasterxml.aalto.stax.InputFactoryImpl;
+import com.fasterxml.aalto.stax.OutputFactoryImpl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -36,8 +38,6 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLEventWriter;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 
@@ -69,8 +69,8 @@ public final class XmlPrimaryMaid implements XmlMaid {
         final long res;
         try (InputStream in = Files.newInputStream(this.file);
             OutputStream out = Files.newOutputStream(tmp)) {
-            final XMLEventReader reader = XMLInputFactory.newInstance().createXMLEventReader(in);
-            final XMLEventWriter writer = XMLOutputFactory.newInstance().createXMLEventWriter(out);
+            final XMLEventReader reader = new InputFactoryImpl().createXMLEventReader(in);
+            final XMLEventWriter writer = new OutputFactoryImpl().createXMLEventWriter(out);
             try {
                 final XMLEventFactory events = XMLEventFactory.newFactory();
                 writer.add(reader.nextEvent());


### PR DESCRIPTION
Part of #388 
1) I've found implementations of `XMLEventReader/XMLEventWriter` which work times faster than standard ones - 2 seconds against 4 minutes locally for 86 mb xml file. Tests and benchmarks will be added later.
2) Added skeleton for new sdk API - it will work with streams as our colleagues want. `RpmMetadata` has two classes, one for removing and second for adding info about provided RPM packages. 