### PR TITLE
Implemented RpmMetadata.Remove

### DIFF
--- a/src/main/java/com/artipie/rpm/RpmMetadata.java
+++ b/src/main/java/com/artipie/rpm/RpmMetadata.java
@@ -23,10 +23,18 @@
  */
 package com.artipie.rpm;
 
+import com.artipie.rpm.meta.XmlAlter;
+import com.artipie.rpm.meta.XmlMaid;
 import com.artipie.rpm.meta.XmlPackage;
+import com.artipie.rpm.meta.XmlPrimaryMaid;
 import com.artipie.rpm.pkg.FilePackage;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import org.apache.commons.lang3.NotImplementedException;
@@ -59,9 +67,27 @@ public interface RpmMetadata {
         /**
          * Removes records from metadata by RPMs checksums.
          * @param checksums Rpms checksums  to remove by
+         * @throws IOException On io-operation result error
          */
-        public void perform(final Collection<String> checksums) {
-            throw new NotImplementedException("Will be implemented later");
+        public void perform(final Collection<String> checksums) throws IOException {
+            for (final MetadataItem item : this.items) {
+                final XmlMaid maid;
+                final Path temp = Files.createTempFile("rpm-index", "xml");
+                final long res;
+                try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(temp))) {
+                    if (item.type == XmlPackage.PRIMARY) {
+                        maid = new XmlPrimaryMaid.Stream(item.input, out);
+                    } else {
+                        maid = new XmlMaid.ByPkgidAttr.Stream(item.input, out);
+                    }
+                    res = maid.clean(checksums);
+                }
+                try (InputStream input = new BufferedInputStream(Files.newInputStream(temp))) {
+                    new XmlAlter.Stream(input, item.out)
+                        .pkgAttr(item.type.tag(), String.valueOf(res));
+                }
+                Files.delete(temp);
+            }
         }
     }
 

--- a/src/test/java/com/artipie/rpm/RpmMetadataRemoveTest.java
+++ b/src/test/java/com/artipie/rpm/RpmMetadataRemoveTest.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.rpm;
+
+import com.artipie.asto.test.TestResource;
+import com.artipie.rpm.meta.XmlPackage;
+import com.jcabi.matchers.XhtmlMatchers;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.cactoos.list.ListOf;
+import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link RpmMetadata.Remove}.
+ * @since 1.4
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+class RpmMetadataRemoveTest {
+
+    @Test
+    void removesRecord() throws IOException {
+        final ByteArrayOutputStream primary = new ByteArrayOutputStream();
+        final ByteArrayOutputStream filelist = new ByteArrayOutputStream();
+        final String checksum = "7eaefd1cb4f9740558da7f12f9cb5a6141a47f5d064a98d46c29959869af1a44";
+        new RpmMetadata.Remove(
+            new RpmMetadata.MetadataItem(
+                XmlPackage.PRIMARY,
+                new ByteArrayInputStream(
+                    new TestResource("repodata/primary.xml.example").asBytes()
+                ),
+                primary
+            ),
+            new RpmMetadata.MetadataItem(
+                XmlPackage.FILELISTS,
+                new ByteArrayInputStream(
+                    new TestResource("repodata/filelists.xml.example").asBytes()
+                ),
+                filelist
+            )
+        ).perform(new ListOf<>(checksum));
+        MatcherAssert.assertThat(
+            "Record was not removed from primary xml",
+            primary.toString(),
+            new AllOf<>(
+                new ListOf<Matcher<? super String>>(
+                    XhtmlMatchers.hasXPaths(
+                        "/*[local-name()='metadata' and @packages='1']",
+                        //@checkstyle LineLengthCheck (1 line)
+                        "/*[local-name()='metadata']/*[local-name()='package']/*[local-name()='name' and text()='nginx']"
+                    ),
+                    new IsNot<>(new StringContains(checksum))
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "Record was not removed from filelist xml",
+            filelist.toString(),
+            new AllOf<>(
+                new ListOf<Matcher<? super String>>(
+                    XhtmlMatchers.hasXPaths(
+                        "/*[local-name()='filelists' and @packages='1']",
+                        "/*[local-name()='filelists']/*[local-name()='package' and @name='nginx']"
+                    ),
+                    new IsNot<>(new StringContains(checksum))
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
Part of #388 
Implemented `RpmMetadata.Remove` class and added corresponding unit-test. The implementation uses temp file to write an intermediate result. We cannot use Pipied io streams here as operations should be performed one by one.