### PR TITLE
Created `XmlEvent` and its first implementation

### DIFF
--- a/src/main/java/com/artipie/rpm/RpmMetadata.java
+++ b/src/main/java/com/artipie/rpm/RpmMetadata.java
@@ -27,7 +27,6 @@ import com.artipie.rpm.meta.XmlAlter;
 import com.artipie.rpm.meta.XmlMaid;
 import com.artipie.rpm.meta.XmlPackage;
 import com.artipie.rpm.meta.XmlPrimaryMaid;
-import com.artipie.rpm.pkg.FilePackage;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
@@ -37,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 import org.apache.commons.lang3.NotImplementedException;
 
 /**
@@ -106,18 +106,25 @@ public interface RpmMetadata {
         private final Collection<MetadataItem> items;
 
         /**
+         * Digest algorithm.
+         */
+        private final Digest digest;
+
+        /**
          * Ctor.
+         * @param digest Digest algorithm
          * @param items Metadata items
          */
-        public Append(final MetadataItem... items) {
+        public Append(final Digest digest, final MetadataItem... items) {
+            this.digest = digest;
             this.items = Arrays.asList(items);
         }
 
         /**
          * Appends records about provided RPMs.
-         * @param packages Rpms to append info about
+         * @param packages Rpms to append info about, map of the path to file and location
          */
-        public void perform(final Collection<FilePackage> packages) {
+        public void perform(final Map<Path, String> packages) {
             throw new NotImplementedException("Not implemented yet");
         }
     }

--- a/src/main/java/com/artipie/rpm/meta/XmlEvent.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlEvent.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.rpm.meta;
+
+import com.artipie.rpm.pkg.HeaderTags;
+import com.artipie.rpm.pkg.Package;
+import java.io.IOException;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.XMLEvent;
+
+/**
+ * Xml event to write to the output stream.
+ * @since 1.5
+ */
+public interface XmlEvent {
+
+    /**
+     * Contracts {@link XMLEvent} with provided metadata.
+     * @param meta Info to build {@link XMLEvent} with
+     * @throws IOException On IO error
+     */
+    void add(Package.Meta meta) throws IOException;
+
+    /**
+     * Implementation of {@link XmlEvent} to build event for {@link XmlPackage#OTHER} package.
+     * @since 1.5
+     * @checkstyle ExecutableStatementCountCheck (30 lines)
+     */
+    class Others implements XmlEvent {
+
+        /**
+         * Where to write the event.
+         */
+        private final XMLEventWriter writer;
+
+        /**
+         * Ctor.
+         * @param writer Writer to write the event
+         */
+        public Others(final XMLEventWriter writer) {
+            this.writer = writer;
+        }
+
+        @Override
+        public void add(final Package.Meta meta) throws IOException {
+            final XMLEventFactory events = XMLEventFactory.newFactory();
+            final HeaderTags tags = new HeaderTags(meta);
+            try {
+                final String pkg = "package";
+                final String version = "version";
+                this.writer.add(events.createStartElement("", "", pkg));
+                this.writer.add(events.createAttribute("pkgid", meta.checksum().hex()));
+                this.writer.add(events.createAttribute("name", tags.name()));
+                this.writer.add(events.createAttribute("arch", tags.arch()));
+                this.writer.add(events.createStartElement("", "", version));
+                this.writer.add(events.createAttribute("epoch", String.valueOf(tags.epoch())));
+                this.writer.add(events.createAttribute("ver", tags.version()));
+                this.writer.add(events.createAttribute("rel", tags.release()));
+                this.writer.add(events.createEndElement("", "", version));
+                for (final String changelog : tags.changelog()) {
+                    final ChangelogEntry entry = new ChangelogEntry(changelog);
+                    final String tag = "changelog";
+                    this.writer.add(events.createStartElement("", "", tag));
+                    this.writer.add(events.createAttribute("date", String.valueOf(entry.date())));
+                    this.writer.add(events.createAttribute("author", entry.author()));
+                    this.writer.add(events.createCharacters(entry.content()));
+                    this.writer.add(events.createEndElement("", "", tag));
+                }
+                this.writer.add(events.createEndElement("", "", pkg));
+            } catch (final XMLStreamException err) {
+                throw new IOException(err);
+            }
+        }
+    }
+}

--- a/src/main/java/com/artipie/rpm/pkg/FilePackage.java
+++ b/src/main/java/com/artipie/rpm/pkg/FilePackage.java
@@ -101,7 +101,7 @@ public final class FilePackage implements Package {
      * File package metadata.
      * @since 0.6
      */
-    static final class Headers implements Meta {
+    public static final class Headers implements Meta {
 
         /**
          * Native headers.
@@ -131,7 +131,8 @@ public final class FilePackage implements Package {
          * @param location File relative location
          * @checkstyle ParameterNumberCheck (10 lines)
          */
-        Headers(final Header hdr, final Path file, final Digest digest, final String location) {
+        public Headers(final Header hdr, final Path file, final Digest digest,
+            final String location) {
             this.hdr = hdr;
             this.file = file;
             this.digest = digest;
@@ -144,7 +145,7 @@ public final class FilePackage implements Package {
          * @param file File path
          * @param digest Digest
          */
-        Headers(final Header hdr, final Path file, final Digest digest) {
+        public Headers(final Header hdr, final Path file, final Digest digest) {
             this(hdr, file, digest, file.getFileName().toString());
         }
 

--- a/src/main/java/com/artipie/rpm/pkg/FilePackageHeader.java
+++ b/src/main/java/com/artipie/rpm/pkg/FilePackageHeader.java
@@ -40,7 +40,7 @@ import org.redline_rpm.header.Header;
  *
  * @since 0.10
  */
-final class FilePackageHeader {
+public final class FilePackageHeader {
 
     /**
      * The RPM file.
@@ -52,7 +52,7 @@ final class FilePackageHeader {
      *
      * @param file The RPM file.
      */
-    FilePackageHeader(final Path file) {
+    public FilePackageHeader(final Path file) {
         this.file = file;
     }
 
@@ -64,7 +64,7 @@ final class FilePackageHeader {
      * @throws IOException In case of I/O error.
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    Header header() throws InvalidPackageException, IOException {
+    public Header header() throws InvalidPackageException, IOException {
         try (FileChannel chan = FileChannel.open(this.file, StandardOpenOption.READ)) {
             final Format format;
             try {

--- a/src/test/java/com/artipie/rpm/meta/XmlEventOthersTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlEventOthersTest.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.rpm.meta;
+
+import com.artipie.asto.test.TestResource;
+import com.artipie.rpm.Digest;
+import com.artipie.rpm.hm.IsXmlEqual;
+import com.artipie.rpm.pkg.FilePackage;
+import com.artipie.rpm.pkg.FilePackageHeader;
+import com.fasterxml.aalto.stax.OutputFactoryImpl;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLStreamException;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test for {@link XmlEvent.Others}.
+ * @since 1.5
+ */
+class XmlEventOthersTest {
+
+    /**
+     * Temporary directory for all tests.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @TempDir
+    Path tmp;
+
+    @Test
+    void writesPackageInfo() throws XMLStreamException, IOException {
+        final Path res = Files.createTempFile(this.tmp, "others", ".xml");
+        final Path file = new TestResource("abc-1.01-26.git20200127.fc32.ppc64le.rpm").asPath();
+        try (OutputStream out = Files.newOutputStream(res)) {
+            final XMLEventWriter writer = new OutputFactoryImpl().createXMLEventWriter(out);
+            new XmlEvent.Others(writer).add(
+                new FilePackage.Headers(new FilePackageHeader(file).header(), file, Digest.SHA256)
+            );
+            writer.close();
+        }
+        MatcherAssert.assertThat(
+            res,
+            new IsXmlEqual(
+                String.join(
+                    "\n",
+                    //@checkstyle LineLengthCheck (1 line)
+                    "<package pkgid=\"b9d10ae3485a5c5f71f0afb1eaf682bfbea4ea667cc3c3975057d6e3d8f2e905\" name=\"abc\" arch=\"ppc64le\">",
+                    "<version epoch=\"0\" ver=\"1.01\" rel=\"26.git20200127.fc32\"/>",
+                    "</package>"
+                )
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
Part of #388 
Created `XmlEvent` - interface to add info about rpm package to the writer and first implementation to write `others.xml`.
Also changed `RpmMetadata.Append` signature: digest algorithm is required to calculate rpm checksum, use `FilePackage` is not a good idea as it has its methods that are not suitable for external usage.