### PR TITLE
Created implementation of `XmlEvent` for filelists.xml

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlEvent.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlEvent.java
@@ -52,7 +52,7 @@ public interface XmlEvent {
      * Implementation of {@link XmlEvent} to build event for `package` and `version` tags.
      * @since 1.5
      */
-    class PackageAndVersion implements XmlEvent {
+    final class PackageAndVersion implements XmlEvent {
 
         /**
          * Where to write the event.
@@ -93,7 +93,7 @@ public interface XmlEvent {
      * Implementation of {@link XmlEvent} to build event for {@link XmlPackage#OTHER} package.
      * @since 1.5
      */
-    class Other implements XmlEvent {
+    final class Other implements XmlEvent {
 
         /**
          * Where to write the event.
@@ -134,7 +134,7 @@ public interface XmlEvent {
      * Implementation of {@link XmlEvent} to build event for {@link XmlPackage#FILELISTS} package.
      * @since 1.5
      */
-    class Filelists implements XmlEvent {
+    final class Filelists implements XmlEvent {
 
         /**
          * Where to write the event.
@@ -161,6 +161,9 @@ public interface XmlEvent {
                 final int[] did = tags.dirIndexes();
                 for (int idx = 0; idx < files.length; idx += 1) {
                     final String fle = files[idx];
+                    // @checkstyle MethodBodyCommentsCheck (2 lines)
+                    // @todo #388:30min This condition is not covered with unit test, extend
+                    //  the test to check this case and make sure it works properly.
                     if (fle.isEmpty() || fle.charAt(0) == '.') {
                         continue;
                     }

--- a/src/main/java/com/artipie/rpm/meta/XmlEvent.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlEvent.java
@@ -26,6 +26,9 @@ package com.artipie.rpm.meta;
 import com.artipie.rpm.pkg.HeaderTags;
 import com.artipie.rpm.pkg.Package;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLStreamException;
@@ -35,6 +38,7 @@ import javax.xml.stream.events.XMLEvent;
  * Xml event to write to the output stream.
  * @since 1.5
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public interface XmlEvent {
 
     /**
@@ -45,11 +49,10 @@ public interface XmlEvent {
     void add(Package.Meta meta) throws IOException;
 
     /**
-     * Implementation of {@link XmlEvent} to build event for {@link XmlPackage#OTHER} package.
+     * Implementation of {@link XmlEvent} to build event for `package` and `version` tags.
      * @since 1.5
-     * @checkstyle ExecutableStatementCountCheck (30 lines)
      */
-    class Others implements XmlEvent {
+    class PackageAndVersion implements XmlEvent {
 
         /**
          * Where to write the event.
@@ -60,7 +63,7 @@ public interface XmlEvent {
          * Ctor.
          * @param writer Writer to write the event
          */
-        public Others(final XMLEventWriter writer) {
+        public PackageAndVersion(final XMLEventWriter writer) {
             this.writer = writer;
         }
 
@@ -68,9 +71,9 @@ public interface XmlEvent {
         public void add(final Package.Meta meta) throws IOException {
             final XMLEventFactory events = XMLEventFactory.newFactory();
             final HeaderTags tags = new HeaderTags(meta);
+            final String pkg = "package";
+            final String version = "version";
             try {
-                final String pkg = "package";
-                final String version = "version";
                 this.writer.add(events.createStartElement("", "", pkg));
                 this.writer.add(events.createAttribute("pkgid", meta.checksum().hex()));
                 this.writer.add(events.createAttribute("name", tags.name()));
@@ -80,6 +83,37 @@ public interface XmlEvent {
                 this.writer.add(events.createAttribute("ver", tags.version()));
                 this.writer.add(events.createAttribute("rel", tags.release()));
                 this.writer.add(events.createEndElement("", "", version));
+            } catch (final XMLStreamException err) {
+                throw new IOException(err);
+            }
+        }
+    }
+
+    /**
+     * Implementation of {@link XmlEvent} to build event for {@link XmlPackage#OTHER} package.
+     * @since 1.5
+     */
+    class Other implements XmlEvent {
+
+        /**
+         * Where to write the event.
+         */
+        private final XMLEventWriter writer;
+
+        /**
+         * Ctor.
+         * @param writer Writer to write the event
+         */
+        public Other(final XMLEventWriter writer) {
+            this.writer = writer;
+        }
+
+        @Override
+        public void add(final Package.Meta meta) throws IOException {
+            final XMLEventFactory events = XMLEventFactory.newFactory();
+            final HeaderTags tags = new HeaderTags(meta);
+            try {
+                new PackageAndVersion(this.writer).add(meta);
                 for (final String changelog : tags.changelog()) {
                     final ChangelogEntry entry = new ChangelogEntry(changelog);
                     final String tag = "changelog";
@@ -89,7 +123,56 @@ public interface XmlEvent {
                     this.writer.add(events.createCharacters(entry.content()));
                     this.writer.add(events.createEndElement("", "", tag));
                 }
-                this.writer.add(events.createEndElement("", "", pkg));
+                this.writer.add(events.createEndElement("", "", "package"));
+            } catch (final XMLStreamException err) {
+                throw new IOException(err);
+            }
+        }
+    }
+
+    /**
+     * Implementation of {@link XmlEvent} to build event for {@link XmlPackage#FILELISTS} package.
+     * @since 1.5
+     */
+    class Filelists implements XmlEvent {
+
+        /**
+         * Where to write the event.
+         */
+        private final XMLEventWriter writer;
+
+        /**
+         * Ctor.
+         * @param writer Writer to write the event
+         */
+        public Filelists(final XMLEventWriter writer) {
+            this.writer = writer;
+        }
+
+        @Override
+        public void add(final Package.Meta meta) throws IOException {
+            final XMLEventFactory events = XMLEventFactory.newFactory();
+            final HeaderTags tags = new HeaderTags(meta);
+            try {
+                new PackageAndVersion(this.writer).add(meta);
+                final String[] files = tags.baseNames().toArray(new String[0]);
+                final String[] dirs = tags.dirNames().toArray(new String[0]);
+                final Set<String> dirset = Arrays.stream(dirs).collect(Collectors.toSet());
+                final int[] did = tags.dirIndexes();
+                for (int idx = 0; idx < files.length; idx += 1) {
+                    final String fle = files[idx];
+                    if (fle.isEmpty() || fle.charAt(0) == '.') {
+                        continue;
+                    }
+                    final String path = String.format("%s%s", dirs[did[idx]], fle);
+                    this.writer.add(events.createStartElement("", "", "file"));
+                    if (dirset.contains(String.format("%s/", path))) {
+                        this.writer.add(events.createAttribute("type", "dir"));
+                    }
+                    this.writer.add(events.createCharacters(path));
+                    this.writer.add(events.createEndElement("", "", "file"));
+                }
+                this.writer.add(events.createEndElement("", "", "package"));
             } catch (final XMLStreamException err) {
                 throw new IOException(err);
             }

--- a/src/test/java/com/artipie/rpm/meta/XmlEventFilelistsTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlEventFilelistsTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Test for {@link XmlEvent.Other}.
  * @since 1.5
+ * @todo #388:30min Extend this test to check
  */
 class XmlEventFilelistsTest {
 

--- a/src/test/java/com/artipie/rpm/meta/XmlEventFilelistsTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlEventFilelistsTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Test for {@link XmlEvent.Other}.
  * @since 1.5
- * @todo #388:30min Extend this test to check
  */
 class XmlEventFilelistsTest {
 

--- a/src/test/java/com/artipie/rpm/meta/XmlEventFilelistsTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlEventFilelistsTest.java
@@ -40,10 +40,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Test for {@link XmlEvent.Others}.
+ * Test for {@link XmlEvent.Other}.
  * @since 1.5
  */
-class XmlEventOthersTest {
+class XmlEventFilelistsTest {
 
     /**
      * Temporary directory for all tests.
@@ -54,11 +54,11 @@ class XmlEventOthersTest {
 
     @Test
     void writesPackageInfo() throws XMLStreamException, IOException {
-        final Path res = Files.createTempFile(this.tmp, "others", ".xml");
-        final Path file = new TestResource("abc-1.01-26.git20200127.fc32.ppc64le.rpm").asPath();
+        final Path res = Files.createTempFile(this.tmp, "filelists", ".xml");
+        final Path file = new TestResource("libdeflt1_0-2020.03.27-25.1.armv7hl.rpm").asPath();
         try (OutputStream out = Files.newOutputStream(res)) {
             final XMLEventWriter writer = new OutputFactoryImpl().createXMLEventWriter(out);
-            new XmlEvent.Others(writer).add(
+            new XmlEvent.Filelists(writer).add(
                 new FilePackage.Headers(new FilePackageHeader(file).header(), file, Digest.SHA256)
             );
             writer.close();
@@ -69,8 +69,11 @@ class XmlEventOthersTest {
                 String.join(
                     "\n",
                     //@checkstyle LineLengthCheck (1 line)
-                    "<package pkgid=\"b9d10ae3485a5c5f71f0afb1eaf682bfbea4ea667cc3c3975057d6e3d8f2e905\" name=\"abc\" arch=\"ppc64le\">",
-                    "<version epoch=\"0\" ver=\"1.01\" rel=\"26.git20200127.fc32\"/>",
+                    "<package pkgid=\"47bbb8b2401e8853812e6340f4197252b92463c132f64a257e18c0c8c83ae462\" name=\"libdeflt1_0\" arch=\"armv7hl\">",
+                    "<version epoch=\"0\" ver=\"2020.03.27\" rel=\"25.1\"/>",
+                    "<file>/usr/lib/libdeflt.so.1.0</file>",
+                    "<file type=\"dir\">/usr/share/licenses/libdeflt1_0</file>",
+                    "<file>/usr/share/licenses/libdeflt1_0/CDDL.Schily.txt</file>",
                     "</package>"
                 )
             )

--- a/src/test/java/com/artipie/rpm/meta/XmlEventOtherTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlEventOtherTest.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.rpm.meta;
+
+import com.artipie.asto.test.TestResource;
+import com.artipie.rpm.Digest;
+import com.artipie.rpm.hm.IsXmlEqual;
+import com.artipie.rpm.pkg.FilePackage;
+import com.artipie.rpm.pkg.FilePackageHeader;
+import com.fasterxml.aalto.stax.OutputFactoryImpl;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLStreamException;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test for {@link XmlEvent.Other}.
+ * @since 1.5
+ */
+class XmlEventOtherTest {
+
+    /**
+     * Temporary directory for all tests.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @TempDir
+    Path tmp;
+
+    @Test
+    void writesPackageInfo() throws XMLStreamException, IOException {
+        final Path res = Files.createTempFile(this.tmp, "others", ".xml");
+        final Path file = new TestResource("abc-1.01-26.git20200127.fc32.ppc64le.rpm").asPath();
+        try (OutputStream out = Files.newOutputStream(res)) {
+            final XMLEventWriter writer = new OutputFactoryImpl().createXMLEventWriter(out);
+            new XmlEvent.Other(writer).add(
+                new FilePackage.Headers(new FilePackageHeader(file).header(), file, Digest.SHA256)
+            );
+            writer.close();
+        }
+        MatcherAssert.assertThat(
+            res,
+            new IsXmlEqual(
+                String.join(
+                    "\n",
+                    //@checkstyle LineLengthCheck (1 line)
+                    "<package pkgid=\"b9d10ae3485a5c5f71f0afb1eaf682bfbea4ea667cc3c3975057d6e3d8f2e905\" name=\"abc\" arch=\"ppc64le\">",
+                    "<version epoch=\"0\" ver=\"1.01\" rel=\"26.git20200127.fc32\"/>",
+                    "</package>"
+                )
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
Part of #388 
Created implementations of `XmlEvent`
- `PackageAndVersion` to add `package` and `version` tags (these tags are used in other and filelists)
- `Filelists` to add rpm item to filelists.xml and corresponding test

Also renamed `XmlEvent.Others` to `XmlEvent.Other` (without `s`) to correspond to xml index file name.