### PR TITLE
Perform independent operations in parallel

### DIFF
--- a/src/main/java/com/artipie/rpm/RpmMetadata.java
+++ b/src/main/java/com/artipie/rpm/RpmMetadata.java
@@ -31,6 +31,7 @@ import com.artipie.rpm.meta.XmlEvent;
 import com.artipie.rpm.meta.XmlMaid;
 import com.artipie.rpm.meta.XmlPackage;
 import com.artipie.rpm.meta.XmlPrimaryMaid;
+import com.jcabi.log.Logger;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
@@ -157,7 +158,7 @@ public interface RpmMetadata {
                 service.awaitTermination(Long.MAX_VALUE, TimeUnit.HOURS);
             } catch (final InterruptedException err) {
                 Thread.currentThread().interrupt();
-                throw new IOException("Failed to update metadata", err);
+                Logger.error(this, err.getMessage());
             } finally {
                 Files.delete(temp);
             }

--- a/src/main/java/com/artipie/rpm/RpmMetadata.java
+++ b/src/main/java/com/artipie/rpm/RpmMetadata.java
@@ -36,12 +36,18 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Rpm metadata class works with xml metadata - adds or removes records about xml packages.
@@ -145,24 +151,60 @@ public interface RpmMetadata {
                     res = new MergedXmlPrimary(primary.input, out)
                         .merge(packages, this.digest, new XmlEvent.Primary());
                 }
-                try (InputStream input = new BufferedInputStream(Files.newInputStream(temp))) {
-                    new XmlAlter.Stream(input, primary.out)
-                        .pkgAttr(primary.type.tag(), String.valueOf(res.count()));
-                }
-                final MetadataItem other = this.items.stream()
-                    .filter(item -> item.type == XmlPackage.OTHER).findFirst().get();
-                new MergedXmlPackage(other.input, other.out, XmlPackage.OTHER, res)
-                    .merge(packages, this.digest, new XmlEvent.Other());
-                final Optional<MetadataItem> filelist = this.items.stream()
-                    .filter(item -> item.type == XmlPackage.FILELISTS).findFirst();
-                if (filelist.isPresent()) {
-                    new MergedXmlPackage(
-                        filelist.get().input, filelist.get().out, XmlPackage.FILELISTS, res
-                    ).merge(packages, this.digest, new XmlEvent.Filelists());
-                }
+                final ExecutorService service = Executors.newFixedThreadPool(3);
+                service.submit(setPrimaryPckg(temp, res, primary));
+                service.submit(updateOther(packages, res));
+                service.submit(updateFilelist(packages, res));
+                service.shutdown();
+                service.awaitTermination(Long.MAX_VALUE, TimeUnit.HOURS);
+            } catch (final InterruptedException err) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Failed to update metadata", err.getCause());
             } finally {
                 Files.delete(temp);
             }
+        }
+
+        private Runnable updateFilelist(final Map<Path, String> packages,
+            final MergedXml.Result res) {
+            return () -> {
+                final Optional<MetadataItem> filelist = this.items.stream()
+                    .filter(item -> item.type == XmlPackage.FILELISTS).findFirst();
+                if (filelist.isPresent()) {
+                    try {
+                        new MergedXmlPackage(
+                            filelist.get().input, filelist.get().out, XmlPackage.FILELISTS, res
+                        ).merge(packages, this.digest, new XmlEvent.Filelists());
+                    } catch (final IOException err) {
+                        throw new UncheckedIOException(err);
+                    }
+                }
+            };
+        }
+
+        private Runnable updateOther(final Map<Path, String> packages, final MergedXml.Result res) {
+            return () -> {
+                try {
+                    final MetadataItem other = this.items.stream()
+                    .filter(item -> item.type == XmlPackage.OTHER).findFirst().get();
+                    new MergedXmlPackage(other.input, other.out, XmlPackage.OTHER, res)
+                        .merge(packages, this.digest, new XmlEvent.Other());
+                } catch (final IOException err) {
+                    throw new UncheckedIOException(err);
+                }
+            };
+        }
+
+        private Runnable setPrimaryPckg(final Path temp, final MergedXml.Result res,
+            final MetadataItem primary) {
+            return () -> {
+                try (InputStream input = new BufferedInputStream(Files.newInputStream(temp))) {
+                    new XmlAlter.Stream(input, primary.out)
+                        .pkgAttr(primary.type.tag(), String.valueOf(res.count()));
+                } catch (final IOException err) {
+                    throw new UncheckedIOException(err);
+                }
+            };
         }
     }
 


### PR DESCRIPTION
Part of #388 
Made `RpmMetadata.Append` perform independent operations in parallel.