### PR TITLE
Remove from empty indexes

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlPrimaryMaid.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlPrimaryMaid.java
@@ -97,10 +97,7 @@ public final class XmlPrimaryMaid implements XmlMaid {
                     new OutputFactoryImpl().createXMLEventWriter(this.out);
                 try {
                     final XMLEventFactory events = XMLEventFactory.newFactory();
-                    writer.add(reader.nextEvent());
-                    writer.add(events.createSpace("\n"));
-                    writer.add(reader.nextEvent());
-                    writer.add(reader.nextEvent());
+                    MergedXmlPackage.startDocument(writer, "-1", XmlPackage.PRIMARY);
                     res = Stream.processPackages(ids, reader, writer);
                     writer.add(events.createSpace("\n"));
                     writer.add(

--- a/src/test/java/com/artipie/rpm/RpmMetadataRemoveTest.java
+++ b/src/test/java/com/artipie/rpm/RpmMetadataRemoveTest.java
@@ -5,6 +5,7 @@
 package com.artipie.rpm;
 
 import com.artipie.asto.test.TestResource;
+import com.artipie.rpm.hm.IsXmlEqual;
 import com.artipie.rpm.meta.XmlPackage;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.io.ByteArrayInputStream;
@@ -17,12 +18,15 @@ import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsNot;
 import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Test for {@link RpmMetadata.Remove}.
  * @since 1.4
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class RpmMetadataRemoveTest {
 
     @Test
@@ -72,6 +76,55 @@ class RpmMetadataRemoveTest {
                     new IsNot<>(new StringContains(checksum))
                 )
             )
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "filelists_1.xml.example,other_1.xml.example,primary_1.xml.example",
+        "filelists_2.xml.example,other_2.xml.example,primary_2.xml.example"
+    })
+    void doesNothingIfIndexIsEmpty(final String ilist, final String iother, final String iprim) {
+        final ByteArrayOutputStream primary = new ByteArrayOutputStream();
+        final ByteArrayOutputStream other = new ByteArrayOutputStream();
+        final ByteArrayOutputStream filelists = new ByteArrayOutputStream();
+        new RpmMetadata.Remove(
+            new RpmMetadata.MetadataItem(
+                XmlPackage.PRIMARY,
+                new ByteArrayInputStream(
+                    new TestResource(String.format("repodata/empty/%s", iprim)).asBytes()
+                ),
+                primary
+            ),
+            new RpmMetadata.MetadataItem(
+                XmlPackage.OTHER,
+                new ByteArrayInputStream(
+                    new TestResource(String.format("repodata/empty/%s", iother)).asBytes()
+                ),
+                other
+            ),
+            new RpmMetadata.MetadataItem(
+                XmlPackage.FILELISTS,
+                new ByteArrayInputStream(
+                    new TestResource(String.format("repodata/empty/%s", ilist)).asBytes()
+                ),
+                filelists
+            )
+        ).perform(new ListOf<>("abc123"));
+        MatcherAssert.assertThat(
+            "Primary xml is not the same",
+            new TestResource(String.format("repodata/empty/%s", iprim)).asPath(),
+            new IsXmlEqual(primary.toByteArray())
+        );
+        MatcherAssert.assertThat(
+            "Other xml is not the same",
+            new TestResource(String.format("repodata/empty/%s", iother)).asPath(),
+            new IsXmlEqual(other.toByteArray())
+        );
+        MatcherAssert.assertThat(
+            "Filelists xml is not the same",
+            new TestResource(String.format("repodata/empty/%s", ilist)).asPath(),
+            new IsXmlEqual(filelists.toByteArray())
         );
     }
 }

--- a/src/test/java/com/artipie/rpm/meta/XmlPrimaryMaidTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlPrimaryMaidTest.java
@@ -32,7 +32,7 @@ class XmlPrimaryMaidTest {
         );
         MatcherAssert.assertThat(
             file,
-            new IsXmlEqual(new TestResource("repodata/primary.xml.example.second").asPath())
+            new IsXmlEqual(new TestResource("repodata/primary.xml.example_maid.second").asPath())
         );
     }
 
@@ -47,7 +47,7 @@ class XmlPrimaryMaidTest {
         );
         MatcherAssert.assertThat(
             file,
-            new IsXmlEqual(new TestResource("repodata/primary.xml.example.first").asPath())
+            new IsXmlEqual(new TestResource("repodata/primary.xml.example_maid.first").asPath())
         );
     }
 

--- a/src/test/resources-binary/repodata/empty/filelists_1.xml.example
+++ b/src/test/resources-binary/repodata/empty/filelists_1.xml.example
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<filelists xmlns="http://linux.duke.edu/metadata/other" packages="0"/>
+<filelists xmlns="http://linux.duke.edu/metadata/filelists" packages="0"/>

--- a/src/test/resources-binary/repodata/empty/filelists_2.xml.example
+++ b/src/test/resources-binary/repodata/empty/filelists_2.xml.example
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<filelists xmlns="http://linux.duke.edu/metadata/other" packages="0">
+<filelists xmlns="http://linux.duke.edu/metadata/filelists" packages="0">
 </filelists>

--- a/src/test/resources-binary/repodata/empty/primary_1.xml.example
+++ b/src/test/resources-binary/repodata/empty/primary_1.xml.example
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<metadata xmlns="http://linux.duke.edu/metadata/other" packages="0"/>
+<metadata xmlns="http://linux.duke.edu/metadata/common" xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="0"/>

--- a/src/test/resources-binary/repodata/empty/primary_2.xml.example
+++ b/src/test/resources-binary/repodata/empty/primary_2.xml.example
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<metadata xmlns="http://linux.duke.edu/metadata/other" packages="0">
+<metadata xmlns="http://linux.duke.edu/metadata/common" xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="0">
 </metadata>

--- a/src/test/resources-binary/repodata/primary.xml.example_maid.first
+++ b/src/test/resources-binary/repodata/primary.xml.example_maid.first
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://linux.duke.edu/metadata/common" xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="-1">
+<package type="rpm">
+  <name>aom</name>
+  <arch>aarch64</arch>
+  <version epoch="0" ver="1.0.0" rel="8.20190810git9666276.el8"/>
+  <checksum type="sha256" pkgid="YES">7eaefd1cb4f9740558da7f12f9cb5a6141a47f5d064a98d46c29959869af1a44</checksum>
+  <summary>Royalty-free next-generation video format</summary>
+  <description>The Alliance for Open Media's focus is to deliver a next-generation
+video format that is:
+
+ - Interoperable and open;
+ - Optimized for the Internet;
+ - Scalable to any modern device at any bandwidth;
+ - Designed with a low computational footprint and optimized for hardware;
+ - Capable of consistent, highest-quality, real-time video delivery; and
+ - Flexible for both commercial and non-commercial content, including
+   user-generated content.
+
+This package contains the reference encoder and decoder.</description>
+  <packager>Fedora Project</packager>
+  <url>http://aomedia.org/</url>
+  <time file="1583929109" build="1565445971"/>
+  <size package="215876" installed="832964" archive="835132"/>
+  <location href="aom-1.0.0-8.20190810git9666276.el8.aarch64.rpm"/>
+  <format>
+    <rpm:license>BSD</rpm:license>
+    <rpm:vendor>Fedora Project</rpm:vendor>
+    <rpm:group>Unspecified</rpm:group>
+    <rpm:buildhost>buildvm-aarch64-12.arm.fedoraproject.org</rpm:buildhost>
+    <rpm:sourcerpm>aom-1.0.0-8.20190810git9666276.el8.src.rpm</rpm:sourcerpm>
+    <rpm:header-range start="4504" end="11024"/>
+    <rpm:provides>
+      <rpm:entry name="aom" flags="EQ" epoch="0" ver="1.0.0" rel="8.20190810git9666276.el8"/>
+      <rpm:entry name="aom(aarch-64)" flags="EQ" epoch="0" ver="1.0.0" rel="8.20190810git9666276.el8"/>
+      <rpm:entry name="av1" flags="EQ" epoch="0" ver="1.0.0" rel="8.20190810git9666276.el8"/>
+    </rpm:provides>
+    <rpm:requires>
+      <rpm:entry name="ld-linux-aarch64.so.1()(64bit)"/>
+      <rpm:entry name="ld-linux-aarch64.so.1(GLIBC_2.17)(64bit)"/>
+      <rpm:entry name="libaom(aarch-64)" flags="EQ" epoch="0" ver="1.0.0" rel="8.20190810git9666276.el8"/>
+      <rpm:entry name="libaom.so.0()(64bit)"/>
+      <rpm:entry name="libgcc_s.so.1()(64bit)"/>
+      <rpm:entry name="libgcc_s.so.1(GCC_3.0)(64bit)"/>
+      <rpm:entry name="libm.so.6()(64bit)"/>
+      <rpm:entry name="libm.so.6(GLIBC_2.17)(64bit)"/>
+      <rpm:entry name="libpthread.so.0()(64bit)"/>
+      <rpm:entry name="libpthread.so.0(GLIBC_2.17)(64bit)"/>
+      <rpm:entry name="libstdc++.so.6()(64bit)"/>
+      <rpm:entry name="libstdc++.so.6(CXXABI_1.3)(64bit)"/>
+      <rpm:entry name="libstdc++.so.6(CXXABI_1.3.8)(64bit)"/>
+      <rpm:entry name="libstdc++.so.6(GLIBCXX_3.4)(64bit)"/>
+      <rpm:entry name="libstdc++.so.6(GLIBCXX_3.4.15)(64bit)"/>
+      <rpm:entry name="rtld(GNU_HASH)"/>
+      <rpm:entry name="libc.so.6(GLIBC_2.17)(64bit)"/>
+    </rpm:requires>
+    <file>/usr/bin/aomdec</file>
+    <file>/usr/bin/aomenc</file>
+  </format>
+</package>
+</metadata>

--- a/src/test/resources-binary/repodata/primary.xml.example_maid.second
+++ b/src/test/resources-binary/repodata/primary.xml.example_maid.second
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://linux.duke.edu/metadata/common" xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="-1">
+<package type="rpm">
+  <name>nginx</name>
+  <arch>x86_64</arch>
+  <version epoch="1" ver="1.16.1" rel="1.el8.ngx"/>
+  <checksum type="sha256" pkgid="YES">54f1d9a1114fa85cd748174c57986004857b800fe9545fbf23af53f4791b31e2</checksum>
+  <summary>High performance web server</summary>
+  <description>nginx [engine x] is an HTTP and reverse proxy server, as well as
+a mail proxy server.</description>
+  <packager></packager>
+  <url>http://nginx.org/</url>
+  <time file="1583848125" build="1565708687"/>
+  <size package="816120" installed="3003616" archive="3009208"/>
+  <location href="nginx-1.16.1-1.el8.ngx.x86_64.rpm"/>
+  <format>
+    <rpm:license>2-clause BSD-like license</rpm:license>
+    <rpm:vendor>Nginx, Inc.</rpm:vendor>
+    <rpm:group>System Environment/Daemons</rpm:group>
+    <rpm:buildhost>rhel8-amd64-builder-builder.gnt.nginx.com</rpm:buildhost>
+    <rpm:sourcerpm>nginx-1.16.1-1.el8.ngx.src.rpm</rpm:sourcerpm>
+    <rpm:header-range start="5112" end="22964"/>
+    <rpm:provides>
+      <rpm:entry name="config(nginx)" flags="EQ" epoch="1" ver="1.16.1" rel="1.el8.ngx"/>
+      <rpm:entry name="nginx" flags="EQ" epoch="1" ver="1.16.1" rel="1.el8.ngx"/>
+      <rpm:entry name="nginx(x86-64)" flags="EQ" epoch="1" ver="1.16.1" rel="1.el8.ngx"/>
+      <rpm:entry name="webserver"/>
+    </rpm:provides>
+    <rpm:requires>
+      <rpm:entry name="/bin/sh" pre="1"/>
+      <rpm:entry name="/bin/sh"/>
+      <rpm:entry name="libcrypt.so.1()(64bit)"/>
+      <rpm:entry name="libcrypt.so.1(XCRYPT_2.0)(64bit)"/>
+      <rpm:entry name="libcrypto.so.1.1()(64bit)"/>
+      <rpm:entry name="libcrypto.so.1.1(OPENSSL_1_1_0)(64bit)"/>
+      <rpm:entry name="libdl.so.2()(64bit)"/>
+      <rpm:entry name="libdl.so.2(GLIBC_2.2.5)(64bit)"/>
+      <rpm:entry name="libpcre.so.1()(64bit)"/>
+      <rpm:entry name="libpthread.so.0()(64bit)"/>
+      <rpm:entry name="libpthread.so.0(GLIBC_2.2.5)(64bit)"/>
+      <rpm:entry name="libpthread.so.0(GLIBC_2.3.2)(64bit)"/>
+      <rpm:entry name="libssl.so.1.1()(64bit)"/>
+      <rpm:entry name="libssl.so.1.1(OPENSSL_1_1_0)(64bit)"/>
+      <rpm:entry name="libssl.so.1.1(OPENSSL_1_1_1)(64bit)"/>
+      <rpm:entry name="libz.so.1()(64bit)"/>
+      <rpm:entry name="rtld(GNU_HASH)"/>
+      <rpm:entry name="shadow-utils" pre="1"/>
+      <rpm:entry name="systemd" pre="1"/>
+      <rpm:entry name="systemd"/>
+      <rpm:entry name="libc.so.6(GLIBC_2.28)(64bit)"/>
+    </rpm:requires>
+    <file>/etc/logrotate.d/nginx</file>
+    <file type="dir">/etc/nginx</file>
+    <file type="dir">/etc/nginx/conf.d</file>
+    <file>/etc/nginx/conf.d/default.conf</file>
+    <file>/etc/nginx/fastcgi_params</file>
+    <file>/etc/nginx/koi-utf</file>
+    <file>/etc/nginx/koi-win</file>
+    <file>/etc/nginx/mime.types</file>
+    <file>/etc/nginx/modules</file>
+    <file>/etc/nginx/nginx.conf</file>
+    <file>/etc/nginx/scgi_params</file>
+    <file>/etc/nginx/uwsgi_params</file>
+    <file>/etc/nginx/win-utf</file>
+    <file>/etc/sysconfig/nginx</file>
+    <file>/etc/sysconfig/nginx-debug</file>
+    <file>/usr/sbin/nginx</file>
+    <file>/usr/sbin/nginx-debug</file>
+  </format>
+</package>
+</metadata>


### PR DESCRIPTION
Closes #415 
Corrected `RpmMetadata.Remove()` to work with empty indexes properly.