### PR TITLE
Correct dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,11 +127,12 @@ SOFTWARE.
       <groupId>com.fasterxml</groupId>
       <artifactId>aalto-xml</artifactId>
       <version>1.2.2</version>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>


### PR DESCRIPTION
Closes #423 
Removed `log4j` and excluded `com.fasterxml.jackson.core/jackson-databind`, apache.ant is not in our in pom and vertx is in the text scope.