### PR TITLE
Changes `Metadata.Append.perform()` signature

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2020 artipie.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/rpm/meta/MergedXml.java
+++ b/src/main/java/com/artipie/rpm/meta/MergedXml.java
@@ -4,12 +4,10 @@
  */
 package com.artipie.rpm.meta;
 
-import com.artipie.rpm.Digest;
 import com.artipie.rpm.pkg.InvalidPackageException;
+import com.artipie.rpm.pkg.Package;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Map;
 
 /**
  * Merged xml: merge provided packages into existing xml index.
@@ -20,12 +18,11 @@ public interface MergedXml {
     /**
      * Appends provided packages to the index xml.
      * @param packages Packages to append info about
-     * @param dgst Digest algorithm
      * @param event Event constant and to append
      * @return Merge result
      * @throws IOException On error
      */
-    Result merge(Map<Path, String> packages, Digest dgst, XmlEvent event) throws IOException;
+    Result merge(Collection<Package.Meta> packages, XmlEvent event) throws IOException;
 
     /**
      * Merge result.

--- a/src/main/java/com/artipie/rpm/meta/MergedXmlPackage.java
+++ b/src/main/java/com/artipie/rpm/meta/MergedXmlPackage.java
@@ -4,16 +4,13 @@
  */
 package com.artipie.rpm.meta;
 
-import com.artipie.rpm.Digest;
-import com.artipie.rpm.pkg.FilePackage;
-import com.artipie.rpm.pkg.FilePackageHeader;
+import com.artipie.rpm.pkg.Package;
 import com.fasterxml.aalto.stax.InputFactoryImpl;
 import com.fasterxml.aalto.stax.OutputFactoryImpl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -91,7 +88,7 @@ public final class MergedXmlPackage implements MergedXml {
     }
 
     @Override
-    public MergedXml.Result merge(final Map<Path, String> packages, final Digest dgst,
+    public MergedXml.Result merge(final Collection<Package.Meta> packages,
         final XmlEvent event) throws IOException {
         try {
             Optional<XMLEventReader> reader = Optional.empty();
@@ -105,14 +102,9 @@ public final class MergedXmlPackage implements MergedXml {
                 if (reader.isPresent()) {
                     this.process(this.res.checksums(), reader.get(), writer);
                 }
-                for (final Path item : packages.keySet()) {
+                for (final Package.Meta item : packages) {
                     new MergedXml.InvalidPackage(
-                        () -> event.add(
-                            writer,
-                            new FilePackage.Headers(
-                                new FilePackageHeader(item).header(), item, dgst
-                            )
-                        ), this.skip
+                        () -> event.add(writer, item), this.skip
                     ).handle();
                 }
                 writer.add(events.createSpace("\n"));
@@ -153,7 +145,7 @@ public final class MergedXmlPackage implements MergedXml {
     /**
      * Process lines. Header and root tag opening are written by method
      * {@link MergedXmlPackage#startDocument(XMLEventWriter, String, XmlPackage)} call in
-     * {@link MergedXmlPackage#merge(Map, Digest, XmlEvent)}, that's why
+     * {@link MergedXmlPackage#merge(Collection, XmlEvent)}, that's why
      * we skip first two events here.
      * @param ids Not valid ids list
      * @param reader Reader

--- a/src/main/java/com/artipie/rpm/pkg/FilePackage.java
+++ b/src/main/java/com/artipie/rpm/pkg/FilePackage.java
@@ -164,7 +164,7 @@ public final class FilePackage implements Package {
      *
      * @since 0.6.3
      */
-    private static final class EntryHeader implements MetaHeader {
+    public static final class EntryHeader implements MetaHeader {
 
         /**
          * Native header entry.
@@ -175,7 +175,7 @@ public final class FilePackage implements Package {
          * Ctor.
          * @param entry Native header entry
          */
-        EntryHeader(final AbstractHeader.Entry<?> entry) {
+        public EntryHeader(final AbstractHeader.Entry<?> entry) {
             this(Optional.ofNullable(entry));
         }
 

--- a/src/test/java/com/artipie/rpm/RpmMetadataAppendTest.java
+++ b/src/test/java/com/artipie/rpm/RpmMetadataAppendTest.java
@@ -6,13 +6,13 @@ package com.artipie.rpm;
 
 import com.artipie.asto.test.TestResource;
 import com.artipie.rpm.meta.XmlPackage;
+import com.artipie.rpm.pkg.FilePackage;
+import com.artipie.rpm.pkg.FilePackageHeader;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.file.Path;
-import org.cactoos.map.MapEntry;
-import org.cactoos.map.MapOf;
+import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
@@ -28,8 +28,9 @@ class RpmMetadataAppendTest {
     void appendsRecords() throws IOException {
         final ByteArrayOutputStream primary = new ByteArrayOutputStream();
         final ByteArrayOutputStream other = new ByteArrayOutputStream();
+        final TestRpm.Libdeflt libdeflt = new TestRpm.Libdeflt();
+        final TestRpm.Abc abc = new TestRpm.Abc();
         new RpmMetadata.Append(
-            Digest.SHA256,
             new RpmMetadata.MetadataItem(
                 XmlPackage.PRIMARY,
                 new ByteArrayInputStream(
@@ -45,14 +46,14 @@ class RpmMetadataAppendTest {
                 other
             )
         ).perform(
-            new MapOf<Path, String>(
-                new MapEntry<>(
-                    new TestRpm.Libdeflt().path(),
-                    new TestRpm.Libdeflt().path().getFileName().toString()
+            new ListOf<>(
+                new FilePackage.Headers(
+                    new FilePackageHeader(libdeflt.path()).header(),
+                    libdeflt.path(), Digest.SHA256, libdeflt.path().getFileName().toString()
                 ),
-                new MapEntry<>(
-                    new TestRpm.Abc().path(),
-                    new TestRpm.Abc().path().getFileName().toString()
+                new FilePackage.Headers(
+                    new FilePackageHeader(abc.path()).header(),
+                    abc.path(), Digest.SHA256, abc.path().getFileName().toString()
                 )
             )
         );
@@ -82,11 +83,12 @@ class RpmMetadataAppendTest {
     }
 
     @Test
-    void createsIndexesWhenInputsAreAbsent() {
+    void createsIndexesWhenInputsAreAbsent() throws IOException {
         final ByteArrayOutputStream primary = new ByteArrayOutputStream();
         final ByteArrayOutputStream other = new ByteArrayOutputStream();
+        final TestRpm.Time time = new TestRpm.Time();
+        final TestRpm.Abc abc = new TestRpm.Abc();
         new RpmMetadata.Append(
-            Digest.SHA256,
             new RpmMetadata.MetadataItem(
                 XmlPackage.PRIMARY,
                 primary
@@ -96,14 +98,14 @@ class RpmMetadataAppendTest {
                 other
             )
         ).perform(
-            new MapOf<Path, String>(
-                new MapEntry<>(
-                    new TestRpm.Time().path(),
-                    new TestRpm.Time().path().getFileName().toString()
+            new ListOf<>(
+                new FilePackage.Headers(
+                    new FilePackageHeader(time.path()).header(),
+                    time.path(), Digest.SHA256, time.path().getFileName().toString()
                 ),
-                new MapEntry<>(
-                    new TestRpm.Abc().path(),
-                    new TestRpm.Abc().path().getFileName().toString()
+                new FilePackage.Headers(
+                    new FilePackageHeader(abc.path()).header(),
+                    abc.path(), Digest.SHA256, abc.path().getFileName().toString()
                 )
             )
         );


### PR DESCRIPTION
Part of #428 
Changed `Metadata.Append.perform()` signature, corrected tests and all the code. Added class `RpmItem`, this`Package.Meta` implementation will be used by our colleagues. 

As now rpm file is parsed outside, parameter `skip` to skip invalid packages is not valid, I'll remove in the next PR.