### PR TITLE
Parameter skip removed from `RpmMetadata.Append`

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2020 artipie.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/rpm/RpmMetadata.java
+++ b/src/main/java/com/artipie/rpm/RpmMetadata.java
@@ -115,26 +115,11 @@ public interface RpmMetadata {
         private final Collection<MetadataItem> items;
 
         /**
-         * Should invalid packages be skipped? Default value is true.
-         */
-        private final boolean skip;
-
-        /**
-         * Ctor.
-         * @param skip Should invalid packages be skipped?
-         * @param items Metadata items
-         */
-        public Append(final boolean skip, final MetadataItem... items) {
-            this.skip = skip;
-            this.items = Arrays.asList(items);
-        }
-
-        /**
          * Ctor.
          * @param items Metadata items
          */
         public Append(final MetadataItem... items) {
-            this(true, items);
+            this.items = Arrays.asList(items);
         }
 
         /**
@@ -151,7 +136,7 @@ public interface RpmMetadata {
                     final MetadataItem primary = this.items.stream()
                         .filter(item -> item.type == XmlPackage.PRIMARY).findFirst().get();
                     try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(temp))) {
-                        res = new MergedXmlPrimary(primary.input, out, this.skip)
+                        res = new MergedXmlPrimary(primary.input, out)
                             .merge(packages, new XmlEvent.Primary());
                     }
                     final ExecutorService service = Executors.newFixedThreadPool(3);
@@ -185,8 +170,7 @@ public interface RpmMetadata {
                 if (filelist.isPresent()) {
                     try {
                         new MergedXmlPackage(
-                            filelist.get().input, filelist.get().out, XmlPackage.FILELISTS,
-                            res, this.skip
+                            filelist.get().input, filelist.get().out, XmlPackage.FILELISTS, res
                         ).merge(packages, new XmlEvent.Filelists());
                     } catch (final IOException err) {
                         throw new ArtipieIOException(err);
@@ -207,7 +191,7 @@ public interface RpmMetadata {
                 try {
                     final MetadataItem other = this.items.stream()
                         .filter(item -> item.type == XmlPackage.OTHER).findFirst().get();
-                    new MergedXmlPackage(other.input, other.out, XmlPackage.OTHER, res, this.skip)
+                    new MergedXmlPackage(other.input, other.out, XmlPackage.OTHER, res)
                         .merge(packages, new XmlEvent.Other());
                 } catch (final IOException err) {
                     throw new ArtipieIOException(err);

--- a/src/main/java/com/artipie/rpm/meta/MergedXmlPackage.java
+++ b/src/main/java/com/artipie/rpm/meta/MergedXmlPackage.java
@@ -51,26 +51,19 @@ public final class MergedXmlPackage implements MergedXml {
     private final MergedXml.Result res;
 
     /**
-     * Should invalid packages be skipped?
-     */
-    private final boolean skip;
-
-    /**
      * Ctor.
      * @param input Input stream
      * @param out Output stream
      * @param type Xml package type
      * @param res Result of the primary.xml merging
-     * @param skip Should invalid packages be skipped?
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public MergedXmlPackage(final Optional<InputStream> input, final OutputStream out,
-        final XmlPackage type, final MergedXml.Result res, final boolean skip) {
+        final XmlPackage type, final MergedXml.Result res) {
         this.input = input;
         this.out = out;
         this.type = type;
         this.res = res;
-        this.skip = skip;
     }
 
     /**
@@ -79,12 +72,11 @@ public final class MergedXmlPackage implements MergedXml {
      * @param out Output stream
      * @param type Xml package type
      * @param res Result of the primary.xml merging
-     * @param skip Should invalid packages be skipped?
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public MergedXmlPackage(final InputStream input, final OutputStream out,
-        final XmlPackage type, final MergedXml.Result res, final boolean skip) {
-        this(Optional.of(input), out, type, res, skip);
+        final XmlPackage type, final MergedXml.Result res) {
+        this(Optional.of(input), out, type, res);
     }
 
     @Override
@@ -103,9 +95,7 @@ public final class MergedXmlPackage implements MergedXml {
                     this.process(this.res.checksums(), reader.get(), writer);
                 }
                 for (final Package.Meta item : packages) {
-                    new MergedXml.InvalidPackage(
-                        () -> event.add(writer, item), this.skip
-                    ).handle();
+                    event.add(writer, item);
                 }
                 writer.add(events.createSpace("\n"));
                 writer.add(

--- a/src/main/java/com/artipie/rpm/meta/MergedXmlPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/MergedXmlPrimary.java
@@ -44,31 +44,22 @@ public final class MergedXmlPrimary implements MergedXml {
     private final OutputStream out;
 
     /**
-     * Should invalid packages be skipped?
-     */
-    private final boolean skip;
-
-    /**
      * Ctor.
      * @param input Input stream
      * @param out Output stream
-     * @param skip Should invalid packages be skipped?
      */
-    public MergedXmlPrimary(final Optional<InputStream> input, final OutputStream out,
-        final boolean skip) {
+    public MergedXmlPrimary(final Optional<InputStream> input, final OutputStream out) {
         this.input = input;
         this.out = out;
-        this.skip = skip;
     }
 
     /**
      * Ctor.
      * @param input Input stream
      * @param out Output stream
-     * @param skip Should invalid packages be skipped?
      */
-    public MergedXmlPrimary(final InputStream input, final OutputStream out, final boolean skip) {
-        this(Optional.of(input), out, skip);
+    public MergedXmlPrimary(final InputStream input, final OutputStream out) {
+        this(Optional.of(input), out);
     }
 
     // @checkstyle ExecutableStatementCountCheck (100 lines)
@@ -93,13 +84,8 @@ public final class MergedXmlPrimary implements MergedXml {
                     );
                 }
                 for (final Package.Meta item : packages) {
-                    new InvalidPackage(
-                        () -> {
-                            event.add(writer, item);
-                            res.incrementAndGet();
-                        },
-                        this.skip
-                    ).handle();
+                    event.add(writer, item);
+                    res.incrementAndGet();
                 }
                 writer.add(events.createSpace("\n"));
                 writer.add(

--- a/src/test/java/com/artipie/rpm/meta/MergedXmlPackageTest.java
+++ b/src/test/java/com/artipie/rpm/meta/MergedXmlPackageTest.java
@@ -9,22 +9,16 @@ import com.artipie.rpm.Digest;
 import com.artipie.rpm.TestRpm;
 import com.artipie.rpm.pkg.FilePackage;
 import com.artipie.rpm.pkg.FilePackageHeader;
-import com.artipie.rpm.pkg.InvalidPackageException;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Optional;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -47,7 +41,7 @@ class MergedXmlPackageTest {
             final XmlPackage type = XmlPackage.valueOf(filename.toUpperCase(Locale.US));
             new MergedXmlPackage(
                 input, out, type,
-                new MergedXmlPrimary.Result(3L, Collections.emptyList()), true
+                new MergedXmlPrimary.Result(3L, Collections.emptyList())
             ).merge(
                 new ListOf<>(
                     new FilePackage.Headers(
@@ -84,7 +78,7 @@ class MergedXmlPackageTest {
             final XmlPackage type = XmlPackage.valueOf(filename.toUpperCase(Locale.US));
             new MergedXmlPackage(
                 input, out, type,
-                new MergedXmlPrimary.Result(2L, Collections.singleton("abc123")), true
+                new MergedXmlPrimary.Result(2L, Collections.singleton("abc123"))
             ).merge(
                 new ListOf<>(
                     new FilePackage.Headers(
@@ -125,7 +119,7 @@ class MergedXmlPackageTest {
             final XmlPackage type = XmlPackage.valueOf(filename.toUpperCase(Locale.US));
             new MergedXmlPackage(
                 input, out, type,
-                new MergedXmlPrimary.Result(4L, Collections.singleton("abc123")), true
+                new MergedXmlPrimary.Result(4L, Collections.singleton("abc123"))
             ).merge(
                 new ListOf<>(
                     new FilePackage.Headers(
@@ -174,7 +168,7 @@ class MergedXmlPackageTest {
             );
             new MergedXmlPackage(
                 input, out, type,
-                new MergedXmlPrimary.Result(1L, Collections.emptyList()), true
+                new MergedXmlPrimary.Result(1L, Collections.emptyList())
             ).merge(
                 new ListOf<>(
                     new FilePackage.Headers(
@@ -198,80 +192,6 @@ class MergedXmlPackageTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"other", "filelists"})
-    @Disabled
-    void skipsInvalidPackage(final String filename, @TempDir final Path tmp) throws IOException {
-        final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        final Path invalid = tmp.resolve("invalid.rpm");
-        Files.write(invalid, "abc123".getBytes());
-        final TestRpm time = new TestRpm.Time();
-        try (InputStream input = new TestResource(
-            String.format("repodata/MergedXmlTest/libdeflt-nginx-%s.xml.example", filename)
-        ).asInputStream()
-        ) {
-            final XmlPackage type = XmlPackage.valueOf(filename.toUpperCase(Locale.US));
-            new MergedXmlPackage(
-                input, out, type,
-                new MergedXmlPrimary.Result(3L, Collections.emptyList()), true
-            ).merge(
-                new ListOf<>(
-                    new FilePackage.Headers(
-                        new FilePackageHeader(time.path()).header(),
-                        time.path(), Digest.SHA256, time.path().getFileName().toString()
-                    ),
-                    new FilePackage.Headers(
-                        new FilePackageHeader(invalid).header(),
-                        invalid, Digest.SHA256, invalid.getFileName().toString()
-                    )
-                ),
-                this.event(type)
-            );
-            final String actual = out.toString(StandardCharsets.UTF_8.name());
-            MatcherAssert.assertThat(
-                actual,
-                XhtmlMatchers.hasXPaths(
-                    // @checkstyle LineLengthCheck (4 lines)
-                    String.format("/*[local-name()='%s' and @packages='3']", type.tag()),
-                    String.format("/*[local-name()='%s']/*[local-name()='package' and @name='libdeflt1_0']", type.tag()),
-                    String.format("/*[local-name()='%s']/*[local-name()='package' and @name='nginx']", type.tag()),
-                    String.format("/*[local-name()='%s']/*[local-name()='package' and @name='time']", type.tag())
-                )
-            );
-        }
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"other", "filelists"})
-    @Disabled
-    void failsWhenInvalidPackageProvided(final String filename, @TempDir final Path tmp)
-        throws IOException {
-        final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        final Path invalid = tmp.resolve("invalid.rpm");
-        Files.write(invalid, "123".getBytes());
-        try (InputStream input = new TestResource(
-            String.format("repodata/MergedXmlTest/libdeflt-nginx-%s.xml.example", filename)
-        ).asInputStream()
-        ) {
-            final XmlPackage type = XmlPackage.valueOf(filename.toUpperCase(Locale.US));
-            Assertions.assertThrows(
-                InvalidPackageException.class,
-                () -> new MergedXmlPackage(
-                    input, out, type,
-                    new MergedXmlPrimary.Result(3L, Collections.emptyList()), false
-                ).merge(
-                    new ListOf<>(
-                        new FilePackage.Headers(
-                            new FilePackageHeader(invalid).header(),
-                            invalid, Digest.SHA256, invalid.getFileName().toString()
-                        )
-                    ),
-                    this.event(type)
-                )
-            );
-        }
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"other", "filelists"})
     void worksWithAbsentInput(final String filename) throws IOException {
         final XmlPackage type = XmlPackage.valueOf(filename.toUpperCase(Locale.US));
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -279,7 +199,7 @@ class MergedXmlPackageTest {
         final TestRpm abc = new TestRpm.Abc();
         new MergedXmlPackage(
             Optional.empty(), out, type,
-            new MergedXmlPrimary.Result(2L, Collections.emptyList()), true
+            new MergedXmlPrimary.Result(2L, Collections.emptyList())
         ).merge(
             new ListOf<>(
                 new FilePackage.Headers(


### PR DESCRIPTION
Part of #428 
As rpm file is parsed outside our sdk, there is no need for `skip` parameter to skip invalid rpm packages. Removed parameter and tests.