### PR TITLE
Added class to pars version parts

### DIFF
--- a/src/main/java/com/artipie/rpm/pkg/HeaderTags.java
+++ b/src/main/java/com/artipie/rpm/pkg/HeaderTags.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.rpm.pkg;
 
+import com.artipie.ArtipieException;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -270,7 +271,7 @@ public final class HeaderTags {
          */
         public String ver() {
             return this.part("ver").orElseThrow(
-                () -> new IllegalArgumentException("Invali version value")
+                () -> new ArtipieException(new IllegalArgumentException("Invalid version value"))
             );
         }
 
@@ -301,7 +302,7 @@ public final class HeaderTags {
             if (matcher.matches()) {
                 return Optional.ofNullable(matcher.group(name));
             }
-            throw new IllegalArgumentException("Provided version is invalid");
+            throw new ArtipieException(new IllegalArgumentException("Provided version is invalid"));
         }
     }
 }

--- a/src/test/java/com/artipie/rpm/pkg/HeaderTagsVersionTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/HeaderTagsVersionTest.java
@@ -4,8 +4,11 @@
  */
 package com.artipie.rpm.pkg;
 
+import com.artipie.ArtipieException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -18,6 +21,7 @@ class HeaderTagsVersionTest {
 
     @ParameterizedTest
     @CsvSource({
+        "5,5",
         "1.0,1.0",
         "1.0.1-26.git20200127.fc32,1.0.1",
         "2.0_1-2.jfh.sdd,2.0_1",
@@ -66,6 +70,14 @@ class HeaderTagsVersionTest {
         MatcherAssert.assertThat(
             new HeaderTags.Version(val).rel().isPresent(),
             new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenVersionNotValid() {
+        Assertions.assertThrows(
+            ArtipieException.class,
+            () -> new HeaderTags.Version("-").ver()
         );
     }
 


### PR DESCRIPTION
Part of #453 
Added `Version` class to parse version parts. In the next PR I'll change `HeaderTags#providesVer` and `HeaderTags#requiresVer()` signature to return lists of `Version` instead of strings.