### PR TITLE
Version allowed symbols

### DIFF
--- a/src/main/java/com/artipie/rpm/pkg/HeaderTags.java
+++ b/src/main/java/com/artipie/rpm/pkg/HeaderTags.java
@@ -274,7 +274,7 @@ public final class HeaderTags {
          * Version format pattern.
          */
         private static final Pattern PTRN =
-            Pattern.compile("((?<epoch>\\d+):)?(?<ver>[^\\-]+|^(?!.))(-(?<rel>.*))?");
+            Pattern.compile("((?<epoch>\\d+):)?(?<ver>[^/-]+|^(?!.))(-(?<rel>[^/-]*))?");
 
         /**
          * Value from version header.

--- a/src/test/java/com/artipie/rpm/pkg/HeaderTagsVersionTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/HeaderTagsVersionTest.java
@@ -8,7 +8,6 @@ import com.artipie.ArtipieException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -76,11 +75,17 @@ class HeaderTagsVersionTest {
         );
     }
 
-    @Test
-    void throwsExceptionWhenVersionNotValid() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "-",
+        "3:sd/sd-2.3alpha",
+        "1/5",
+        "3:1-1-1"
+    })
+    void throwsExceptionWhenVersionNotValid(final String param) {
         Assertions.assertThrows(
             ArtipieException.class,
-            () -> new HeaderTags.Version("-").ver()
+            () -> new HeaderTags.Version(param).ver()
         );
     }
 


### PR DESCRIPTION
Part of #453 
According to `org.redline_rpm.Builder#ILLEGAL_CHARS_VARIABLE` the only illegal chars for version and release are `/` and `-`. I've corrected regex and added more tests. 