### PR TITLE
deps: bump asto to v1.8.0, extract benchmarks as a module

### DIFF
--- a/benchmarks/LICENSE.header
+++ b/benchmarks/LICENSE.header
@@ -1,0 +1,2 @@
+The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+https://github.com/artipie/rpm-adapter/LICENSE.txt

--- a/benchmarks/LICENSE.txt
+++ b/benchmarks/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 artipie.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -29,13 +29,13 @@ SOFTWARE.
     <version>0.5.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.artipie</groupId>
   <artifactId>rpm-bench</artifactId>
+  <groupId>benchmarks</groupId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>jar</packaging>
   <properties>
     <jmh.version>1.29</jmh.version>
-    <asto.version>1.2.0</asto.version>
+    <asto.version>v1.8.0</asto.version>
+    <qulice.license>${project.basedir}/LICENSE.header</qulice.license>
   </properties>
   <dependencies>
     <dependency>

--- a/benchmarks/src/main/java/com/artipie/rpm/RpmBench.java
+++ b/benchmarks/src/main/java/com/artipie/rpm/RpmBench.java
@@ -3,28 +3,22 @@
  * https://github.com/artipie/rpm-adapter/LICENSE.txt
  */
 
-package com.artipie.rpm.benchmarks;
+package com.artipie.rpm;
 
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.fs.FileStorage;
-import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.memory.BenchmarkStorage;
-import com.artipie.asto.rx.RxStorageWrapper;
-import com.artipie.rpm.Rpm;
+import com.artipie.asto.memory.InMemoryStorage;
 import hu.akarnokd.rxjava2.interop.CompletableInterop;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -43,6 +37,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle DesignForExtensionCheck (500 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)

--- a/benchmarks/src/main/java/com/artipie/rpm/RpmMetadataAppendBench.java
+++ b/benchmarks/src/main/java/com/artipie/rpm/RpmMetadataAppendBench.java
@@ -3,22 +3,25 @@
  * https://github.com/artipie/rpm-adapter/LICENSE.txt
  */
 
-package com.artipie.rpm.benchmarks;
+package com.artipie.rpm;
 
-import com.artipie.rpm.RpmMetadata;
 import com.artipie.rpm.meta.XmlPackage;
+import com.artipie.rpm.pkg.FilePackage;
+import com.artipie.rpm.pkg.FilePackageHeader;
+import com.artipie.rpm.pkg.Package;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.cactoos.list.ListOf;
 import org.cactoos.map.MapEntry;
 import org.cactoos.scalar.Unchecked;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -36,7 +39,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
- * Benchmark for {@link com.artipie.rpm.RpmMetadata.Remove}.
+ * Benchmark for {@link RpmMetadata.Append}.
  * @since 1.4
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle DesignForExtensionCheck (500 lines)
@@ -48,7 +51,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @State(Scope.Benchmark)
 @Warmup(iterations = 5)
 @Measurement(iterations = 20)
-public class RpmMetadataRemoveBench {
+public class RpmMetadataAppendBench {
 
     /**
      * Benchmark directory.
@@ -60,13 +63,19 @@ public class RpmMetadataRemoveBench {
      */
     private Map<XmlPackage, byte[]> items;
 
+    /**
+     * Benchmark rpms.
+     */
+    private Collection<Package.Meta> rpms;
+
     @Setup
     public void setup() throws IOException {
-        if (RpmMetadataRemoveBench.BENCH_DIR == null) {
+        if (RpmMetadataAppendBench.BENCH_DIR == null) {
             throw new IllegalStateException("BENCH_DIR environment variable must be set");
         }
-        try (Stream<Path> files = Files.list(Paths.get(RpmMetadataRemoveBench.BENCH_DIR))) {
-            this.items = files.map(
+        try (Stream<Path> files = Files.list(Paths.get(RpmMetadataAppendBench.BENCH_DIR))) {
+            final List<Path> flist = files.collect(Collectors.toList());
+            this.items = flist.stream().map(
                 file -> new XmlPackage.Stream(true).get()
                     .filter(xml -> file.toString().contains(xml.lowercase()))
                     .findFirst().map(
@@ -77,12 +86,19 @@ public class RpmMetadataRemoveBench {
                     )
             ).filter(Optional::isPresent).map(Optional::get)
                 .collect(Collectors.toMap(MapEntry::getKey, MapEntry::getValue));
+            this.rpms = flist.stream().filter(item -> item.endsWith(".rpm"))
+                .map(
+                    item -> new FilePackage.Headers(
+                        new Unchecked<>(() -> new FilePackageHeader(item).header()).value(),
+                        item, Digest.SHA256, item.getFileName().toString()
+                    )
+                ).collect(Collectors.toList());
         }
     }
 
     @Benchmark
     public void run(final Blackhole bhl) throws IOException {
-        new RpmMetadata.Remove(
+        new RpmMetadata.Append(
             this.items.entrySet().stream()
             .map(
                 entry -> new RpmMetadata.MetadataItem(
@@ -91,21 +107,7 @@ public class RpmMetadataRemoveBench {
                     new ByteArrayOutputStream()
                 )
             ).toArray(RpmMetadata.MetadataItem[]::new)
-        ).perform(
-            new ListOf<String>(
-                "35f6b7ceecb3b66d41991358113ae019dbabbac21509afbe770c06d6999d75c7",
-                "8dad6a68a8868c7e4595634affbad8677e48e259dac9180dd73a41ae8414305a",
-                "0ab1a22f716b480392a3fe28e9fafebd61ff8afe3196aa35ccc937413e0a3c4a",
-                "8440d6772087e9b4f0c3db57eb328594d1c18cdacd52f3565cba87fb0ce0cc0d",
-                "3f7e099180803c182194a5277fe6d7e2561550ca51598d5bc3334c11361090af",
-                "2cbe8499cd1c48e0440bcf0a8e4a1e4a336142d521db91e35a546ec99f7c50ac",
-                "05c37cb7b04bfe885f139340fb58aa8e0051b62e4215feded619a8cc726609a3",
-                "3d81ad4030684e997772d2bdf1dd5d8253fb66df68e30a09507aafb49ae359f6",
-                "5eb3cc0a41ea8770c2c4491e7d574e263aa3ae3bb1006a4b9b883abbd58cbfd9",
-                "2b068b878a023ebd9bec65767dea211035dbb2d72470fba08b8ca36a130cc5ec",
-                "5104d2c1feecedc2f19778219530f2f7731b296c5957659aaddc5968a555a020"
-            )
-        );
+        ).perform(this.rpms);
     }
 
     /**
@@ -116,9 +118,7 @@ public class RpmMetadataRemoveBench {
     public static void main(final String... args) throws RunnerException {
         new Runner(
             new OptionsBuilder()
-                .include(RpmMetadataRemoveBench.class.getSimpleName())
-                .forks(1)
-                .build()
+                .include(RpmMetadataAppendBench.class.getSimpleName()).forks(1).build()
         ).run();
     }
 

--- a/benchmarks/src/main/java/com/artipie/rpm/package-info.java
+++ b/benchmarks/src/main/java/com/artipie/rpm/package-info.java
@@ -7,4 +7,4 @@
  * RPM benchmarks.
  * @since 1.4
  */
-package com.artipie.rpm.benchmarks;
+package com.artipie.rpm;

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>v1.7.0</version>
+      <version>v1.8.0</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
Part of artipie/artipie#431
Bumped asto to `v1.8.0`, extracted benchmarks as a separate Maven project