### PR TITLE
dep: bump asto in bench to `v1.9.0`

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -34,7 +34,7 @@ SOFTWARE.
   <version>1.0-SNAPSHOT</version>
   <properties>
     <jmh.version>1.29</jmh.version>
-    <asto.version>v1.8.0</asto.version>
+    <asto.version>v1.9.0</asto.version>
     <qulice.license>${project.basedir}/LICENSE.header</qulice.license>
   </properties>
   <dependencies>


### PR DESCRIPTION
Bumped asto in benchmarks to `v1.9.0` to use class for exclusion keys