### PR TITLE
fix: allow duplicates in requires

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlEvent.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlEvent.java
@@ -293,7 +293,7 @@ public interface XmlEvent {
                     items.put(item, ind);
                     writer.add(events.createEndElement(Primary.PRFX, Primary.NS_URL, "entry"));
                     if (versions.get(ind).ver().isEmpty()) {
-                        duplicates.add(name);
+                        duplicates.add(name.concat(flags.get(ind).orElse("")));
                     }
                 }
             }


### PR DESCRIPTION
`createrepo` generates duplicates on `rpm:requires` section
if entry provides additional constraints to previously defined item.
Fixed rpm-adapter to provide duplicates with additional constraints
as `createrepo`.

Fix: #490