### PR TITLE
Filter files in primary

### DIFF
--- a/src/main/java/com/artipie/rpm/RpmMetadata.java
+++ b/src/main/java/com/artipie/rpm/RpmMetadata.java
@@ -10,6 +10,7 @@ import com.artipie.rpm.meta.MergedXmlPackage;
 import com.artipie.rpm.meta.MergedXmlPrimary;
 import com.artipie.rpm.meta.XmlAlter;
 import com.artipie.rpm.meta.XmlEvent;
+import com.artipie.rpm.meta.XmlEventPrimary;
 import com.artipie.rpm.meta.XmlMaid;
 import com.artipie.rpm.meta.XmlPackage;
 import com.artipie.rpm.meta.XmlPrimaryMaid;
@@ -137,7 +138,7 @@ public interface RpmMetadata {
                         .filter(item -> item.type == XmlPackage.PRIMARY).findFirst().get();
                     try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(temp))) {
                         res = new MergedXmlPrimary(primary.input, out)
-                            .merge(packages, new XmlEvent.Primary());
+                            .merge(packages, new XmlEventPrimary());
                     }
                     final ExecutorService service = Executors.newFixedThreadPool(3);
                     service.submit(Append.setPrimaryPckg(temp, res, primary));

--- a/src/main/java/com/artipie/rpm/asto/AstoMetadataAdd.java
+++ b/src/main/java/com/artipie/rpm/asto/AstoMetadataAdd.java
@@ -15,6 +15,7 @@ import com.artipie.rpm.meta.MergedXmlPackage;
 import com.artipie.rpm.meta.MergedXmlPrimary;
 import com.artipie.rpm.meta.XmlAlter;
 import com.artipie.rpm.meta.XmlEvent;
+import com.artipie.rpm.meta.XmlEventPrimary;
 import com.artipie.rpm.meta.XmlPackage;
 import com.artipie.rpm.pkg.Package;
 import java.io.BufferedInputStream;
@@ -103,7 +104,7 @@ public final class AstoMetadataAdd {
                         (input, out) -> new UncheckedScalar<>(
                             () -> new MergedXmlPrimary(
                                 input.map(new UncheckedIOFunc<>(GZIPInputStream::new)), out
-                            ).merge(metas, new XmlEvent.Primary())
+                            ).merge(metas, new XmlEventPrimary())
                         ).value()
                     ).thenCompose(
                         res -> new StorageValuePipeline<>(this.asto, tempkey).process(

--- a/src/main/java/com/artipie/rpm/meta/XmlEvent.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlEvent.java
@@ -4,24 +4,17 @@
  */
 package com.artipie.rpm.meta;
 
-import com.artipie.rpm.misc.UncheckedConsumer;
 import com.artipie.rpm.pkg.HeaderTags;
 import com.artipie.rpm.pkg.Package;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
-import org.cactoos.map.MapEntry;
-import org.cactoos.map.MapOf;
 
 /**
  * Xml event to write to the output stream.
@@ -119,6 +112,28 @@ public interface XmlEvent {
      */
     final class Files implements XmlEvent {
 
+        /**
+         * Predicate to filter files. The item is NOT added to the writer if
+         * the filter returns TRUE.
+         */
+        private final Predicate<String> filter;
+
+        /**
+         * Ctor.
+         * @param filter Predicate to filter files. The item is NOT added to the writer if
+         *  the filter returns TRUE
+         */
+        public Files(final Predicate<String> filter) {
+            this.filter = filter;
+        }
+
+        /**
+         * Ctor with 'always false' filter.
+         */
+        public Files() {
+            this(name -> false);
+        }
+
         @Override
         public void add(final XMLEventWriter writer, final Package.Meta meta) throws IOException {
             final XMLEventFactory events = XMLEventFactory.newFactory();
@@ -137,6 +152,9 @@ public interface XmlEvent {
                         continue;
                     }
                     final String path = String.format("%s%s", dirs[did[idx]], fle);
+                    if (this.filter.test(path)) {
+                        continue;
+                    }
                     writer.add(events.createStartElement("", "", "file"));
                     if (dirset.contains(String.format("%s/", path))) {
                         writer.add(events.createAttribute("type", "dir"));
@@ -150,285 +168,4 @@ public interface XmlEvent {
         }
     }
 
-    /**
-     * Implementation of {@link XmlEvent} to build event for {@link XmlPackage#PRIMARY} package.
-     * @since 1.5
-     * @checkstyle ExecutableStatementCountCheck (500 lines)
-     * @checkstyle MagicNumberCheck (20 lines)
-     */
-    @SuppressWarnings("PMD.LongVariable")
-    final class Primary implements XmlEvent {
-
-        /**
-         * Legacy prereq dependency.
-         */
-        private static final int RPMSENSE_PREREQ = 1 << 6;
-
-        /**
-         * Pre dependency.
-         */
-        private static final int RPMSENSE_SCRIPT_PRE = 1 << 9;
-
-        /**
-         * Post dependency.
-         */
-        private static final int RPMSENSE_SCRIPT_POST = 1 << 10;
-
-        /**
-         * Xml namespace prefix.
-         */
-        private static final String PRFX = "rpm";
-
-        /**
-         * Primary namespace URL.
-         */
-        private static final String NS_URL = XmlPackage.PRIMARY.xmlNamespaces().get(Primary.PRFX);
-
-        @Override
-        public void add(final XMLEventWriter writer, final Package.Meta meta) throws IOException {
-            final XMLEventFactory events = XMLEventFactory.newFactory();
-            final HeaderTags tags = new HeaderTags(meta);
-            try {
-                writer.add(events.createStartElement("", "", "package"));
-                writer.add(events.createAttribute("type", "rpm"));
-                Primary.addElement(writer, "name", tags.name());
-                Primary.addElement(writer, "arch", tags.arch());
-                writer.add(events.createStartElement("", "", "version"));
-                writer.add(events.createAttribute("epoch", String.valueOf(tags.epoch())));
-                writer.add(events.createAttribute("rel", tags.release()));
-                writer.add(events.createAttribute("ver", tags.version()));
-                writer.add(events.createEndElement("", "", "version"));
-                writer.add(events.createStartElement("", "", "checksum"));
-                writer.add(events.createAttribute("type", meta.checksum().digest().type()));
-                writer.add(events.createAttribute("pkgid", "YES"));
-                writer.add(events.createCharacters(meta.checksum().hex()));
-                writer.add(events.createEndElement("", "", "checksum"));
-                Primary.addElement(writer, "summary", tags.summary());
-                Primary.addElement(writer, "description", tags.description());
-                Primary.addElement(writer, "packager", tags.packager());
-                Primary.addElement(writer, "url", tags.url());
-                Primary.addAttributes(
-                    writer,
-                    "time",
-                    new MapOf<String, String>(
-                        new MapEntry<>("file", String.valueOf(tags.fileTimes())),
-                        new MapEntry<>("build", String.valueOf(tags.buildTime()))
-                    )
-                );
-                Primary.addAttributes(
-                    writer,
-                    "size",
-                    new MapOf<String, String>(
-                        new MapEntry<>("package", String.valueOf(meta.size())),
-                        new MapEntry<>("installed", String.valueOf(tags.installedSize())),
-                        new MapEntry<>("archive", String.valueOf(tags.archiveSize()))
-                    )
-                );
-                Primary.addAttributes(
-                    writer,
-                    "location",
-                    new MapOf<String, String>(new MapEntry<>("href", meta.href()))
-                );
-                writer.add(events.createStartElement("", "", "format"));
-                Primary.addElementWithNamespace(writer, "license", tags.license());
-                Primary.addElementWithNamespace(writer, "vendor", tags.vendor());
-                Primary.addElementWithNamespace(writer, "group", tags.group());
-                Primary.addElementWithNamespace(writer, "buildhost", tags.buildHost());
-                Primary.addElementWithNamespace(writer, "sourcerpm", tags.sourceRmp());
-                Primary.addAttributes(
-                    writer,
-                    "header-range", Primary.NS_URL, Primary.PRFX,
-                    new MapOf<String, String>(
-                        new MapEntry<>("start", String.valueOf(meta.range()[0])),
-                        new MapEntry<>("end", String.valueOf(meta.range()[1]))
-                    )
-                );
-                Primary.addProvides(writer, tags);
-                Primary.addRequires(writer, tags);
-                new Files().add(writer, meta);
-                writer.add(events.createEndElement("", "", "format"));
-                writer.add(events.createEndElement("", "", "package"));
-            } catch (final XMLStreamException err) {
-                throw new IOException(err);
-            }
-        }
-
-        /**
-         * Builds `provides` tag. Attribute `flags` should be present if the version is present and
-         * in `provides` the only possible flag value is `EQ`.
-         * @param writer Xml event writer
-         * @param tags Tag info
-         * @throws XMLStreamException On error
-         */
-        private static void addProvides(final XMLEventWriter writer, final HeaderTags tags)
-            throws XMLStreamException {
-            final XMLEventFactory events = XMLEventFactory.newFactory();
-            writer.add(events.createStartElement(Primary.PRFX, Primary.NS_URL, "provides"));
-            final List<String> names = tags.providesNames();
-            final List<Optional<String>> flags = tags.providesFlags();
-            final List<HeaderTags.Version> versions = tags.providesVer();
-            for (int ind = 0; ind < names.size(); ind = ind + 1) {
-                writer.add(events.createStartElement(Primary.PRFX, Primary.NS_URL, "entry"));
-                writer.add(events.createAttribute("name", names.get(ind)));
-                Primary.addEntryAttr(
-                    writer, events, versions, ind, flags, HeaderTags.Flags.EQUAL.notation()
-                );
-                writer.add(events.createEndElement(Primary.PRFX, Primary.NS_URL, "entry"));
-            }
-            writer.add(events.createEndElement(Primary.PRFX, Primary.NS_URL, "provides"));
-        }
-
-        /**
-         * Builds `requires` tag. Items with names started on `rpmlib(` or `config(` are excluded,
-         * duplicates without version are also excluded.
-         * About `flags` attribute check {@link Primary#findFlag(List, Map, String)}.
-         * @param writer Xml event writer
-         * @param tags Tag info
-         * @throws XMLStreamException On error
-         */
-        private static void addRequires(final XMLEventWriter writer, final HeaderTags tags)
-            throws XMLStreamException {
-            final XMLEventFactory events = XMLEventFactory.newFactory();
-            writer.add(events.createStartElement(Primary.PRFX, Primary.NS_URL, "requires"));
-            final List<String> names = tags.requires();
-            final List<Optional<String>> flags = tags.requireFlags();
-            final List<Integer> intflags = tags.requireFlagsInts();
-            final List<HeaderTags.Version> versions = tags.requiresVer();
-            final Map<String, Integer> items = new HashMap<>(names.size());
-            final Set<String> duplicates = new HashSet<>(names.size());
-            for (int ind = 0; ind < names.size(); ind = ind + 1) {
-                final String name = names.get(ind);
-                int pre = 0;
-                if ((intflags.get(ind)
-                    & (Primary.RPMSENSE_PREREQ
-                    | Primary.RPMSENSE_SCRIPT_PRE
-                    | Primary.RPMSENSE_SCRIPT_POST)) != 0) {
-                    pre = 1;
-                }
-                String full = name.concat(flags.get(ind).orElse(""))
-                    .concat(versions.get(ind).toString());
-                if (!versions.get(ind).toString().isEmpty()) {
-                    full = full.concat(String.valueOf(pre));
-                }
-                if (!name.startsWith("rpmlib(")
-                    && !name.startsWith("config(") && !duplicates.contains(full)) {
-                    writer.add(events.createStartElement(Primary.PRFX, Primary.NS_URL, "entry"));
-                    writer.add(events.createAttribute("name", name));
-                    final String item = String.join("", name, versions.get(ind).toString());
-                    Primary.addEntryAttr(
-                        writer, events, versions, ind, flags, Primary.findFlag(flags, items, item)
-                    );
-                    if (pre > 0) {
-                        writer.add(events.createAttribute("pre", String.valueOf(pre)));
-                    }
-                    items.put(item, ind);
-                    writer.add(events.createEndElement(Primary.PRFX, Primary.NS_URL, "entry"));
-                }
-                duplicates.add(full);
-            }
-            writer.add(events.createEndElement(Primary.PRFX, Primary.NS_URL, "requires"));
-        }
-
-        /**
-         * Adds tag with the provided name and characters.
-         * @param writer Xml event writer
-         * @param tag Tag name
-         * @param chars Characters
-         * @throws XMLStreamException On error
-         */
-        private static void addElementWithNamespace(final XMLEventWriter writer, final String tag,
-            final String chars) throws XMLStreamException {
-            final XMLEventFactory events = XMLEventFactory.newFactory();
-            writer.add(events.createStartElement(Primary.PRFX, Primary.NS_URL, tag));
-            writer.add(events.createCharacters(chars));
-            writer.add(events.createEndElement(Primary.PRFX, Primary.NS_URL, tag));
-        }
-
-        /**
-         * Adds tag with the provided name and characters.
-         * @param writer Xml event writer
-         * @param tag Tag name
-         * @param chars Characters
-         * @throws XMLStreamException On error
-         */
-        private static void addElement(final XMLEventWriter writer, final String tag,
-            final String chars) throws XMLStreamException {
-            final XMLEventFactory events = XMLEventFactory.newFactory();
-            writer.add(events.createStartElement("", "", tag));
-            writer.add(events.createCharacters(chars));
-            writer.add(events.createEndElement("", "", tag));
-        }
-
-        /**
-         * Adds tag with provided attributes list.
-         * @param writer Xml event writer
-         * @param tag Tag name
-         * @param namespace Namespace
-         * @param prefix Prefix
-         * @param attrs Attributes list
-         * @throws XMLStreamException On Error
-         * @checkstyle ParameterNumberCheck (5 lines)
-         */
-        private static void addAttributes(final XMLEventWriter writer, final String tag,
-            final String namespace, final String prefix,
-            final Map<String, String> attrs) throws XMLStreamException {
-            final XMLEventFactory events = XMLEventFactory.newFactory();
-            writer.add(events.createStartElement(prefix, namespace, tag));
-            for (final Map.Entry<String, String> attr : attrs.entrySet()) {
-                writer.add(events.createAttribute(attr.getKey(), attr.getValue()));
-            }
-            writer.add(events.createEndElement(prefix, namespace, tag));
-        }
-
-        /**
-         * Adds tag with provided attributes list.
-         * @param writer Xml event writer
-         * @param tag Tag name
-         * @param attrs Attributes list
-         * @throws XMLStreamException On Error
-         */
-        private static void addAttributes(final XMLEventWriter writer, final String tag,
-            final Map<String, String> attrs) throws XMLStreamException {
-            Primary.addAttributes(writer, tag, "", "", attrs);
-        }
-
-        /**
-         * Write entry attributes ver, epoch and rel.
-         * @param writer Where to write
-         * @param events Xml events
-         * @param versions Versions
-         * @param ind Current index
-         * @param flags Entries flags
-         * @param def Default flag
-         * @throws XMLStreamException On error
-         * @checkstyle ParameterNumberCheck (5 lines)
-         */
-        private static void addEntryAttr(final XMLEventWriter writer, final XMLEventFactory events,
-            final List<HeaderTags.Version> versions, final int ind,
-            final List<Optional<String>> flags, final String def)
-            throws XMLStreamException {
-            if (ind < versions.size() && !versions.get(ind).ver().isEmpty()) {
-                writer.add(events.createAttribute("ver", versions.get(ind).ver()));
-                writer.add(events.createAttribute("epoch", versions.get(ind).epoch()));
-                versions.get(ind).rel().ifPresent(
-                    new UncheckedConsumer<>(rel -> writer.add(events.createAttribute("rel", rel)))
-                );
-                writer.add(events.createAttribute("flags", flags.get(ind).orElse(def)));
-            }
-        }
-
-        /**
-         * Try to find flag for `requires` entry: if there is en entry with such name and version,
-         * use the flag it has. If there is no such entry, write `EQ`.
-         * @param flags Flags list
-         * @param items Items: names and versions
-         * @param item Current name and version
-         * @return Flag value
-         */
-        private static String findFlag(final List<Optional<String>> flags,
-            final Map<String, Integer> items, final String item) {
-            return Optional.ofNullable(items.get(item)).flatMap(flags::get)
-                .orElse(HeaderTags.Flags.EQUAL.notation());
-        }
-    }
 }

--- a/src/main/java/com/artipie/rpm/meta/XmlEventPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlEventPrimary.java
@@ -1,0 +1,334 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/rpm-adapter/LICENSE.txt
+ */
+package com.artipie.rpm.meta;
+
+import com.artipie.rpm.misc.UncheckedConsumer;
+import com.artipie.rpm.pkg.HeaderTags;
+import com.artipie.rpm.pkg.Package;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLStreamException;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+
+/**
+ * Implementation of {@link XmlEvent} to build event for {@link XmlPackage#PRIMARY} package.
+ *
+ * @checkstyle ExecutableStatementCountCheck (500 lines)
+ * @checkstyle MagicNumberCheck (20 lines)
+ * @since 1.5
+ */
+@SuppressWarnings({"PMD.LongVariable", "PMD.AvoidDuplicateLiterals"})
+public final class XmlEventPrimary implements XmlEvent {
+
+    /**
+     * Legacy prereq dependency.
+     */
+    private static final int RPMSENSE_PREREQ = 1 << 6;
+
+    /**
+     * Pre dependency.
+     */
+    private static final int RPMSENSE_SCRIPT_PRE = 1 << 9;
+
+    /**
+     * Post dependency.
+     */
+    private static final int RPMSENSE_SCRIPT_POST = 1 << 10;
+
+    /**
+     * Xml namespace prefix.
+     */
+    private static final String PRFX = "rpm";
+
+    /**
+     * Primary namespace URL.
+     */
+    private static final String NS_URL =
+        XmlPackage.PRIMARY.xmlNamespaces().get(XmlEventPrimary.PRFX);
+
+    @Override
+    public void add(final XMLEventWriter writer, final Package.Meta meta) throws IOException {
+        final XMLEventFactory events = XMLEventFactory.newFactory();
+        final HeaderTags tags = new HeaderTags(meta);
+        try {
+            writer.add(events.createStartElement("", "", "package"));
+            writer.add(events.createAttribute("type", "rpm"));
+            XmlEventPrimary.addElement(writer, "name", tags.name());
+            XmlEventPrimary.addElement(writer, "arch", tags.arch());
+            writer.add(events.createStartElement("", "", "version"));
+            writer.add(events.createAttribute("epoch", String.valueOf(tags.epoch())));
+            writer.add(events.createAttribute("rel", tags.release()));
+            writer.add(events.createAttribute("ver", tags.version()));
+            writer.add(events.createEndElement("", "", "version"));
+            writer.add(events.createStartElement("", "", "checksum"));
+            writer.add(events.createAttribute("type", meta.checksum().digest().type()));
+            writer.add(events.createAttribute("pkgid", "YES"));
+            writer.add(events.createCharacters(meta.checksum().hex()));
+            writer.add(events.createEndElement("", "", "checksum"));
+            XmlEventPrimary.addElement(writer, "summary", tags.summary());
+            XmlEventPrimary.addElement(writer, "description", tags.description());
+            XmlEventPrimary.addElement(writer, "packager", tags.packager());
+            XmlEventPrimary.addElement(writer, "url", tags.url());
+            XmlEventPrimary.addAttributes(
+                writer,
+                "time",
+                new MapOf<String, String>(
+                    new MapEntry<>("file", String.valueOf(tags.fileTimes())),
+                    new MapEntry<>("build", String.valueOf(tags.buildTime()))
+                )
+            );
+            XmlEventPrimary.addAttributes(
+                writer,
+                "size",
+                new MapOf<String, String>(
+                    new MapEntry<>("package", String.valueOf(meta.size())),
+                    new MapEntry<>("installed", String.valueOf(tags.installedSize())),
+                    new MapEntry<>("archive", String.valueOf(tags.archiveSize()))
+                )
+            );
+            XmlEventPrimary.addAttributes(
+                writer,
+                "location",
+                new MapOf<String, String>(new MapEntry<>("href", meta.href()))
+            );
+            writer.add(events.createStartElement("", "", "format"));
+            XmlEventPrimary.addElementWithNamespace(writer, "license", tags.license());
+            XmlEventPrimary.addElementWithNamespace(writer, "vendor", tags.vendor());
+            XmlEventPrimary.addElementWithNamespace(writer, "group", tags.group());
+            XmlEventPrimary.addElementWithNamespace(writer, "buildhost", tags.buildHost());
+            XmlEventPrimary.addElementWithNamespace(writer, "sourcerpm", tags.sourceRmp());
+            XmlEventPrimary.addAttributes(
+                writer,
+                "header-range", XmlEventPrimary.NS_URL, XmlEventPrimary.PRFX,
+                new MapOf<String, String>(
+                    new MapEntry<>("start", String.valueOf(meta.range()[0])),
+                    new MapEntry<>("end", String.valueOf(meta.range()[1]))
+                )
+            );
+            XmlEventPrimary.addProvides(writer, tags);
+            XmlEventPrimary.addRequires(writer, tags);
+            // @checkstyle BooleanExpressionComplexityCheck (10 lines)
+            new Files(
+                name -> name.startsWith("/var") || name.startsWith("/lib64")
+                    || name.startsWith("/run") || name.startsWith("/usr")
+                    && !(name.contains("/bin/") || name.contains("/sbin/"))
+            ).add(writer, meta);
+            writer.add(events.createEndElement("", "", "format"));
+            writer.add(events.createEndElement("", "", "package"));
+        } catch (final XMLStreamException err) {
+            throw new IOException(err);
+        }
+    }
+
+    /**
+     * Builds `provides` tag. Attribute `flags` should be present if the version is present and
+     * in `provides` the only possible flag value is `EQ`.
+     *
+     * @param writer Xml event writer
+     * @param tags Tag info
+     * @throws XMLStreamException On error
+     */
+    private static void addProvides(final XMLEventWriter writer, final HeaderTags tags)
+        throws XMLStreamException {
+        final XMLEventFactory events = XMLEventFactory.newFactory();
+        writer.add(
+            events.createStartElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "provides")
+        );
+        final List<String> names = tags.providesNames();
+        final List<Optional<String>> flags = tags.providesFlags();
+        final List<HeaderTags.Version> versions = tags.providesVer();
+        for (int ind = 0; ind < names.size(); ind = ind + 1) {
+            writer.add(
+                events.createStartElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "entry")
+            );
+            writer.add(events.createAttribute("name", names.get(ind)));
+            XmlEventPrimary.addEntryAttr(
+                writer, events, versions, ind, flags, HeaderTags.Flags.EQUAL.notation()
+            );
+            writer.add(
+                events.createEndElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "entry")
+            );
+        }
+        writer.add(
+            events.createEndElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "provides")
+        );
+    }
+
+    /**
+     * Builds `requires` tag. Items with names started on `rpmlib(` or `config(` are excluded,
+     * duplicates without version are also excluded.
+     * About `flags` attribute check {@link XmlEventPrimary#findFlag(List, Map, String)}.
+     *
+     * @param writer Xml event writer
+     * @param tags Tag info
+     * @throws XMLStreamException On error
+     */
+    private static void addRequires(final XMLEventWriter writer, final HeaderTags tags)
+        throws XMLStreamException {
+        final XMLEventFactory events = XMLEventFactory.newFactory();
+        writer.add(
+            events.createStartElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "requires")
+        );
+        final List<String> names = tags.requires();
+        final List<Optional<String>> flags = tags.requireFlags();
+        final List<Integer> intflags = tags.requireFlagsInts();
+        final List<HeaderTags.Version> versions = tags.requiresVer();
+        final Map<String, Integer> items = new HashMap<>(names.size());
+        final Set<String> duplicates = new HashSet<>(names.size());
+        for (int ind = 0; ind < names.size(); ind = ind + 1) {
+            final String name = names.get(ind);
+            int pre = 0;
+            if ((intflags.get(ind)
+                & (XmlEventPrimary.RPMSENSE_PREREQ
+                | XmlEventPrimary.RPMSENSE_SCRIPT_PRE
+                | XmlEventPrimary.RPMSENSE_SCRIPT_POST)) != 0) {
+                pre = 1;
+            }
+            String full = name.concat(flags.get(ind).orElse(""))
+                .concat(versions.get(ind).toString());
+            if (!versions.get(ind).toString().isEmpty()) {
+                full = full.concat(String.valueOf(pre));
+            }
+            if (!name.startsWith("rpmlib(")
+                && !name.startsWith("config(") && !duplicates.contains(full)) {
+                writer.add(
+                    events.createStartElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "entry")
+                );
+                writer.add(events.createAttribute("name", name));
+                final String item = String.join("", name, versions.get(ind).toString());
+                XmlEventPrimary.addEntryAttr(
+                    writer, events, versions, ind, flags,
+                    XmlEventPrimary.findFlag(flags, items, item)
+                );
+                if (pre > 0) {
+                    writer.add(events.createAttribute("pre", String.valueOf(pre)));
+                }
+                items.put(item, ind);
+                writer.add(
+                    events.createEndElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "entry")
+                );
+            }
+            duplicates.add(full);
+        }
+        writer.add(
+            events.createEndElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "requires")
+        );
+    }
+
+    /**
+     * Adds tag with the provided name and characters.
+     *
+     * @param writer Xml event writer
+     * @param tag Tag name
+     * @param chars Characters
+     * @throws XMLStreamException On error
+     */
+    private static void addElementWithNamespace(final XMLEventWriter writer, final String tag,
+        final String chars) throws XMLStreamException {
+        final XMLEventFactory events = XMLEventFactory.newFactory();
+        writer.add(events.createStartElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, tag));
+        writer.add(events.createCharacters(chars));
+        writer.add(events.createEndElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, tag));
+    }
+
+    /**
+     * Adds tag with the provided name and characters.
+     *
+     * @param writer Xml event writer
+     * @param tag Tag name
+     * @param chars Characters
+     * @throws XMLStreamException On error
+     */
+    private static void addElement(final XMLEventWriter writer, final String tag,
+        final String chars) throws XMLStreamException {
+        final XMLEventFactory events = XMLEventFactory.newFactory();
+        writer.add(events.createStartElement("", "", tag));
+        writer.add(events.createCharacters(chars));
+        writer.add(events.createEndElement("", "", tag));
+    }
+
+    /**
+     * Adds tag with provided attributes list.
+     *
+     * @param writer Xml event writer
+     * @param tag Tag name
+     * @param namespace Namespace
+     * @param prefix Prefix
+     * @param attrs Attributes list
+     * @throws XMLStreamException On Error
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    private static void addAttributes(final XMLEventWriter writer, final String tag,
+        final String namespace, final String prefix, final Map<String, String> attrs)
+        throws XMLStreamException {
+        final XMLEventFactory events = XMLEventFactory.newFactory();
+        writer.add(events.createStartElement(prefix, namespace, tag));
+        for (final Map.Entry<String, String> attr : attrs.entrySet()) {
+            writer.add(events.createAttribute(attr.getKey(), attr.getValue()));
+        }
+        writer.add(events.createEndElement(prefix, namespace, tag));
+    }
+
+    /**
+     * Adds tag with provided attributes list.
+     *
+     * @param writer Xml event writer
+     * @param tag Tag name
+     * @param attrs Attributes list
+     * @throws XMLStreamException On Error
+     */
+    private static void addAttributes(final XMLEventWriter writer, final String tag,
+        final Map<String, String> attrs) throws XMLStreamException {
+        XmlEventPrimary.addAttributes(writer, tag, "", "", attrs);
+    }
+
+    /**
+     * Write entry attributes ver, epoch and rel.
+     *
+     * @param writer Where to write
+     * @param events Xml events
+     * @param versions Versions
+     * @param ind Current index
+     * @param flags Entries flags
+     * @param def Default flag
+     * @throws XMLStreamException On error
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    private static void addEntryAttr(final XMLEventWriter writer, final XMLEventFactory events,
+        final List<HeaderTags.Version> versions, final int ind, final List<Optional<String>> flags,
+        final String def) throws XMLStreamException {
+        if (ind < versions.size() && !versions.get(ind).ver().isEmpty()) {
+            writer.add(events.createAttribute("ver", versions.get(ind).ver()));
+            writer.add(events.createAttribute("epoch", versions.get(ind).epoch()));
+            versions.get(ind).rel().ifPresent(
+                new UncheckedConsumer<>(rel -> writer.add(events.createAttribute("rel", rel)))
+            );
+            writer.add(events.createAttribute("flags", flags.get(ind).orElse(def)));
+        }
+    }
+
+    /**
+     * Try to find flag for `requires` entry: if there is en entry with such name and version,
+     * use the flag it has. If there is no such entry, write `EQ`.
+     *
+     * @param flags Flags list
+     * @param items Items: names and versions
+     * @param item Current name and version
+     * @return Flag value
+     */
+    private static String findFlag(final List<Optional<String>> flags,
+        final Map<String, Integer> items, final String item) {
+        return Optional.ofNullable(items.get(item)).flatMap(flags::get)
+            .orElse(HeaderTags.Flags.EQUAL.notation());
+    }
+}

--- a/src/test/java/com/artipie/rpm/meta/MergedXmlPrimaryTest.java
+++ b/src/test/java/com/artipie/rpm/meta/MergedXmlPrimaryTest.java
@@ -46,7 +46,7 @@ class MergedXmlPrimaryTest {
                             libdeflt.path(), Digest.SHA256, libdeflt.path().getFileName().toString()
                         )
                     ),
-                    new XmlEvent.Primary()
+                    new XmlEventPrimary()
                 );
             MatcherAssert.assertThat(
                 "Packages count is incorrect",
@@ -91,7 +91,7 @@ class MergedXmlPrimaryTest {
                             libdeflt.path(), Digest.SHA256, libdeflt.path().getFileName().toString()
                         )
                     ),
-                    new XmlEvent.Primary()
+                    new XmlEventPrimary()
                 );
             MatcherAssert.assertThat(
                 "Packages count is incorrect",
@@ -143,7 +143,7 @@ class MergedXmlPrimaryTest {
                             libdeflt.path(), Digest.SHA256, libdeflt.path().getFileName().toString()
                         )
                     ),
-                    new XmlEvent.Primary()
+                    new XmlEventPrimary()
                 );
             MatcherAssert.assertThat(
                 "Packages count is incorrect",
@@ -187,7 +187,7 @@ class MergedXmlPrimaryTest {
                         abc.path(), Digest.SHA256, abc.path().getFileName().toString()
                     )
                 ),
-                new XmlEvent.Primary()
+                new XmlEventPrimary()
             );
             MatcherAssert.assertThat(
                 "Packages count is incorrect",
@@ -226,7 +226,7 @@ class MergedXmlPrimaryTest {
                     time.path(), Digest.SHA256, time.path().getFileName().toString()
                 )
             ),
-            new XmlEvent.Primary()
+            new XmlEventPrimary()
         );
         MatcherAssert.assertThat(
             "Packages count is incorrect",

--- a/src/test/java/com/artipie/rpm/meta/XmlEventPrimaryTest.java
+++ b/src/test/java/com/artipie/rpm/meta/XmlEventPrimaryTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.xmlunit.matchers.CompareMatcher;
 
 /**
- * Test for {@link XmlEvent.Primary}.
+ * Test for {@link XmlEventPrimary}.
  * @since 1.5
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -46,7 +46,7 @@ class XmlEventPrimaryTest {
         writer.add(events.createStartElement("", "", "metadata"));
         writer.add(events.createNamespace("http://linux.duke.edu/metadata/common"));
         writer.add(events.createNamespace("rpm", "http://linux.duke.edu/metadata/rpm"));
-        new XmlEvent.Primary().add(
+        new XmlEventPrimary().add(
             writer,
             new FilePackage.Headers(new FilePackageHeader(file).header(), file, Digest.SHA256)
         );
@@ -60,7 +60,6 @@ class XmlEventPrimaryTest {
                 .ignoreWhitespace()
                 .ignoreElementContentWhitespace()
                 .normalizeWhitespace()
-                .withNodeFilter(node -> !"file".equals(node.getLocalName()))
         );
     }
 

--- a/src/test/resources-binary/AstoMetadataAddTest/primary-res.xml
+++ b/src/test/resources-binary/AstoMetadataAddTest/primary-res.xml
@@ -95,9 +95,6 @@
                 <rpm:entry name="libgcc_s.so.1"/>
                 <rpm:entry name="libgcc_s.so.1(GCC_3.5)"/>
             </rpm:requires>
-            <file>/usr/lib/libdeflt.so.1.0</file>
-            <file type="dir">/usr/share/licenses/libdeflt1_0</file>
-            <file>/usr/share/licenses/libdeflt1_0/CDDL.Schily.txt</file>
         </format>
     </package>
     <package type="rpm">
@@ -143,12 +140,6 @@
                 <rpm:entry name="rtld(GNU_HASH)"/>
             </rpm:requires>
             <file>/usr/bin/abc</file>
-            <file type="dir">/usr/lib/.build-id/cb</file>
-            <file>/usr/lib/.build-id/cb/263ca8bdb2d581b1a12e604c0e30635e69c889</file>
-            <file type="dir">/usr/share/doc/abc</file>
-            <file>/usr/share/doc/abc/README.md</file>
-            <file>/usr/share/doc/abc/readmeaig</file>
-            <file>/usr/share/man/man1/abc.1.gz</file>
         </format>
     </package>
 </metadata>

--- a/src/test/resources-binary/XmlEventPrimaryTest/abc_res.xml
+++ b/src/test/resources-binary/XmlEventPrimaryTest/abc_res.xml
@@ -46,12 +46,6 @@
                 <rpm:entry name="rtld(GNU_HASH)"/>
             </rpm:requires>
             <file>/usr/bin/abc</file>
-            <file type="dir">/usr/lib/.build-id/cb</file>
-            <file>/usr/lib/.build-id/cb/263ca8bdb2d581b1a12e604c0e30635e69c889</file>
-            <file type="dir">/usr/share/doc/abc</file>
-            <file>/usr/share/doc/abc/README.md</file>
-            <file>/usr/share/doc/abc/readmeaig</file>
-            <file>/usr/share/man/man1/abc.1.gz</file>
         </format>
     </package>
 </metadata>

--- a/src/test/resources-binary/XmlEventPrimaryTest/ant_res.xml
+++ b/src/test/resources-binary/XmlEventPrimaryTest/ant_res.xml
@@ -51,43 +51,8 @@
             <file>/usr/bin/complete-ant-cmd.pl</file>
             <file>/usr/bin/runant.pl</file>
             <file>/usr/bin/runant.py</file>
-            <file type="dir">/usr/share/ant</file>
-            <file type="dir">/usr/share/ant/bin</file>
             <file>/usr/share/ant/bin/ant</file>
             <file>/usr/share/ant/bin/antRun</file>
-            <file type="dir">/usr/share/ant/etc</file>
-            <file>/usr/share/ant/etc/ant-update.xsl</file>
-            <file>/usr/share/ant/etc/changelog.xsl</file>
-            <file>/usr/share/ant/etc/common2master.xsl</file>
-            <file>/usr/share/ant/etc/coverage-frames.xsl</file>
-            <file>/usr/share/ant/etc/junit-frames-xalan1.xsl</file>
-            <file>/usr/share/ant/etc/log.xsl</file>
-            <file>/usr/share/ant/etc/mmetrics-frames.xsl</file>
-            <file>/usr/share/ant/etc/printFailingTests.xsl</file>
-            <file>/usr/share/ant/etc/tagdiff.xsl</file>
-            <file type="dir">/usr/share/ant/lib</file>
-            <file>/usr/share/ant/lib/ant-bootstrap.jar</file>
-            <file>/usr/share/ant/lib/ant-launcher.jar</file>
-            <file>/usr/share/ant/lib/ant.jar</file>
-            <file type="dir">/usr/share/doc/ant-1.9.4</file>
-            <file>/usr/share/doc/ant-1.9.4/KEYS</file>
-            <file>/usr/share/doc/ant-1.9.4/LICENSE</file>
-            <file>/usr/share/doc/ant-1.9.4/NOTICE</file>
-            <file>/usr/share/doc/ant-1.9.4/README</file>
-            <file>/usr/share/doc/ant-1.9.4/WHATSNEW</file>
-            <file type="dir">/usr/share/java/ant</file>
-            <file>/usr/share/java/ant-bootstrap.jar</file>
-            <file>/usr/share/java/ant-launcher.jar</file>
-            <file>/usr/share/java/ant.jar</file>
-            <file>/usr/share/java/ant/ant-bootstrap.jar</file>
-            <file>/usr/share/java/ant/ant-launcher.jar</file>
-            <file>/usr/share/java/ant/ant.jar</file>
-            <file>/usr/share/maven-fragments/ant</file>
-            <file>/usr/share/maven-fragments/ant-ant</file>
-            <file>/usr/share/maven-fragments/ant-launcher</file>
-            <file>/usr/share/maven-poms/JPP-ant-parent.pom</file>
-            <file>/usr/share/maven-poms/JPP.ant-ant-launcher.pom</file>
-            <file>/usr/share/maven-poms/JPP.ant-ant.pom</file>
         </format>
     </package>
 </metadata>

--- a/src/test/resources-binary/XmlEventPrimaryTest/felix-framework-res.xml
+++ b/src/test/resources-binary/XmlEventPrimaryTest/felix-framework-res.xml
@@ -28,13 +28,6 @@
                 <rpm:entry name="java" ver="1.5" epoch="0" flags="GE"/>
                 <rpm:entry name="jpackage-utils"/>
             </rpm:requires>
-            <file type="dir">/usr/share/doc/felix-framework-4.2.1</file>
-            <file>/usr/share/doc/felix-framework-4.2.1/LICENSE</file>
-            <file>/usr/share/doc/felix-framework-4.2.1/NOTICE</file>
-            <file>/usr/share/java/felix/org.apache.felix.framework.jar</file>
-            <file>/usr/share/maven-effective-poms/JPP.felix-org.apache.felix.framework.pom</file>
-            <file>/usr/share/maven-fragments/felix-framework.xml</file>
-            <file>/usr/share/maven-poms/JPP.felix-org.apache.felix.framework.pom</file>
         </format>
     </package>
 </metadata>

--- a/src/test/resources-binary/XmlEventPrimaryTest/httpd_res.xml
+++ b/src/test/resources-binary/XmlEventPrimaryTest/httpd_res.xml
@@ -65,6 +65,35 @@
                 <rpm:entry name="libz.so.1()(64bit)"/>
                 <rpm:entry name="rtld(GNU_HASH)"/>
             </rpm:requires>
+            <file type="dir">/etc/httpd</file>
+            <file type="dir">/etc/httpd/conf</file>
+            <file type="dir">/etc/httpd/conf.d</file>
+            <file>/etc/httpd/conf.d/README</file>
+            <file>/etc/httpd/conf.d/autoindex.conf</file>
+            <file>/etc/httpd/conf.d/userdir.conf</file>
+            <file>/etc/httpd/conf.d/welcome.conf</file>
+            <file type="dir">/etc/httpd/conf.modules.d</file>
+            <file>/etc/httpd/conf.modules.d/00-base.conf</file>
+            <file>/etc/httpd/conf.modules.d/00-dav.conf</file>
+            <file>/etc/httpd/conf.modules.d/00-lua.conf</file>
+            <file>/etc/httpd/conf.modules.d/00-mpm.conf</file>
+            <file>/etc/httpd/conf.modules.d/00-proxy.conf</file>
+            <file>/etc/httpd/conf.modules.d/00-systemd.conf</file>
+            <file>/etc/httpd/conf.modules.d/01-cgi.conf</file>
+            <file>/etc/httpd/conf/httpd.conf</file>
+            <file>/etc/httpd/conf/magic</file>
+            <file>/etc/httpd/logs</file>
+            <file>/etc/httpd/modules</file>
+            <file>/etc/httpd/run</file>
+            <file>/etc/logrotate.d/httpd</file>
+            <file>/etc/sysconfig/htcacheclean</file>
+            <file>/etc/sysconfig/httpd</file>
+            <file>/usr/sbin/apachectl</file>
+            <file>/usr/sbin/fcgistarter</file>
+            <file>/usr/sbin/htcacheclean</file>
+            <file>/usr/sbin/httpd</file>
+            <file>/usr/sbin/rotatelogs</file>
+            <file>/usr/sbin/suexec</file>
         </format>
     </package>
 </metadata>


### PR DESCRIPTION
Part of #495 
Added filer to `XmlEvent.Files` to filter items in primary.xml. Also, moved `XmlEvent.Primary` class to upper level as it became too large. Corrected tests.