### PR TITLE
fix: enable two tests of NodeHasPkgCountTest on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.llorllale</groupId>
       <artifactId>cactoos-matchers</artifactId>
-      <version>0.18</version>
+      <version>0.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/artipie/rpm/RepoConfigFromYamlTest.java
+++ b/src/test/java/com/artipie/rpm/RepoConfigFromYamlTest.java
@@ -6,11 +6,12 @@ package com.artipie.rpm;
 
 import com.amihaiemil.eoyaml.Yaml;
 import java.util.Optional;
-import org.cactoos.func.ProcOf;
+import org.cactoos.list.ListOf;
+import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.Test;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Satisfies;
 
 /**
  * Test for {@link RepoConfig.FromYaml}.
@@ -27,12 +28,14 @@ public final class RepoConfigFromYamlTest {
                 .add("naming-policy", "sha256").add("filelists", "false")
                 .add("update", Yaml.createYamlMappingBuilder().add("on", "upload").build()).build()
             ),
-            Matchers.allOf(
-                new MatcherOf<>(cnfg -> cnfg.digest() == Digest.SHA1),
-                new MatcherOf<>(cnfg -> cnfg.naming() == StandardNamingPolicy.SHA256),
-                new MatcherOf<>(fromYaml -> !fromYaml.filelists()),
-                new MatcherOf<>(cnfg -> cnfg.mode() == RepoConfig.UpdateMode.UPLOAD),
-                new MatcherOf<>(new ProcOf<>(cnfg -> !cnfg.cron().isPresent()))
+            new AllOf<>(
+                new ListOf<Matcher<? super RepoConfig>>(
+                    new Satisfies<>(cfg -> cfg.digest() == Digest.SHA1),
+                    new Satisfies<>(cfg -> cfg.naming() == StandardNamingPolicy.SHA256),
+                    new Satisfies<>(fromYaml -> !fromYaml.filelists()),
+                    new Satisfies<>(cfg -> cfg.mode() == RepoConfig.UpdateMode.UPLOAD),
+                    new Satisfies<>(cfg -> !cfg.cron().isPresent())
+                )
             )
         );
     }
@@ -51,9 +54,11 @@ public final class RepoConfigFromYamlTest {
                         ).build()
                     ).build()
             ),
-            Matchers.allOf(
-                new MatcherOf<>(cnfg -> cnfg.mode() == RepoConfig.UpdateMode.CRON),
-                new MatcherOf<>(new ProcOf<>(cnfg -> !cnfg.cron().get().equals(cron)))
+            new AllOf<>(
+                new ListOf<Matcher<? super RepoConfig>>(
+                    new Satisfies<>(cfg -> cfg.mode() == RepoConfig.UpdateMode.CRON),
+                    new Satisfies<>(cfg -> cfg.cron().get().equals(cron))
+                )
             )
         );
     }
@@ -62,12 +67,14 @@ public final class RepoConfigFromYamlTest {
     void returnsDefaults() {
         MatcherAssert.assertThat(
             new RepoConfig.FromYaml(Optional.empty()),
-            Matchers.allOf(
-                new MatcherOf<>(cnfg -> cnfg.digest() == Digest.SHA256),
-                new MatcherOf<>(cnfg -> cnfg.naming() == StandardNamingPolicy.SHA256),
-                new MatcherOf<>(new ProcOf<>(RepoConfig.FromYaml::filelists)),
-                new MatcherOf<>(cnfg -> cnfg.mode() == RepoConfig.UpdateMode.UPLOAD),
-                new MatcherOf<>(new ProcOf<>(cnfg -> !cnfg.cron().isPresent()))
+            new AllOf<>(
+                new ListOf<Matcher<? super RepoConfig>>(
+                    new Satisfies<>(cfg -> cfg.digest() == Digest.SHA256),
+                    new Satisfies<>(cfg -> cfg.naming() == StandardNamingPolicy.SHA256),
+                    new Satisfies<>(RepoConfig::filelists),
+                    new Satisfies<>(cfg -> cfg.mode() == RepoConfig.UpdateMode.UPLOAD),
+                    new Satisfies<>(cfg -> !cfg.cron().isPresent())
+                )
             )
         );
     }

--- a/src/test/java/com/artipie/rpm/RpmOptionsTest.java
+++ b/src/test/java/com/artipie/rpm/RpmOptionsTest.java
@@ -11,7 +11,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Satisfies;
 
 /**
  * Tests for {@link RpmOptions}.
@@ -29,10 +29,10 @@ public class RpmOptionsTest {
             new AllOf<>(
                 new ListOf<Matcher<? super Option>>(
                     //@checkstyle LineLengthCheck (5 lines)
-                    new MatcherOf<>(opt -> { return "dgst".equals(opt.getArgName()); }),
-                    new MatcherOf<>(opt -> { return "d".equals(opt.getOpt()); }),
-                    new MatcherOf<>(opt -> { return "(optional, default sha256) configures Digest instance for Rpm: sha256 or sha1".equals(opt.getDescription()); }),
-                    new MatcherOf<>(opt -> { return "digest".equals(opt.getLongOpt()); })
+                    new Satisfies<>(opt -> "dgst".equals(opt.getArgName())),
+                    new Satisfies<>(opt -> "d".equals(opt.getOpt())),
+                    new Satisfies<>(opt -> "(optional, default sha256) configures Digest instance for Rpm: sha256 or sha1".equals(opt.getDescription())),
+                    new Satisfies<>(opt -> "digest".equals(opt.getLongOpt()))
                 )
             )
         );
@@ -45,10 +45,10 @@ public class RpmOptionsTest {
             new AllOf<>(
                 new ListOf<Matcher<? super Option>>(
                     //@checkstyle LineLengthCheck (5 lines)
-                    new MatcherOf<>(opt -> { return "np".equals(opt.getArgName()); }),
-                    new MatcherOf<>(opt -> { return "n".equals(opt.getOpt()); }),
-                    new MatcherOf<>(opt -> { return "(optional, default plain) configures NamingPolicy for Rpm: plain, sha256 or sha1".equals(opt.getDescription()); }),
-                    new MatcherOf<>(opt -> { return "naming-policy".equals(opt.getLongOpt()); })
+                    new Satisfies<>(opt -> "np".equals(opt.getArgName())),
+                    new Satisfies<>(opt -> "n".equals(opt.getOpt())),
+                    new Satisfies<>(opt -> "(optional, default plain) configures NamingPolicy for Rpm: plain, sha256 or sha1".equals(opt.getDescription())),
+                    new Satisfies<>(opt -> "naming-policy".equals(opt.getLongOpt()))
                 )
             )
         );
@@ -61,10 +61,10 @@ public class RpmOptionsTest {
             new AllOf<>(
                 new ListOf<Matcher<? super Option>>(
                     //@checkstyle LineLengthCheck (5 lines)
-                    new MatcherOf<>(opt -> { return "fl".equals(opt.getArgName()); }),
-                    new MatcherOf<>(opt -> { return "f".equals(opt.getOpt()); }),
-                    new MatcherOf<>(opt -> { return "(optional, default true) includes File Lists for Rpm: true or false".equals(opt.getDescription()); }),
-                    new MatcherOf<>(opt -> { return "filelists".equals(opt.getLongOpt()); })
+                    new Satisfies<>(opt -> "fl".equals(opt.getArgName())),
+                    new Satisfies<>(opt -> "f".equals(opt.getOpt())),
+                    new Satisfies<>(opt -> "(optional, default true) includes File Lists for Rpm: true or false".equals(opt.getDescription())),
+                    new Satisfies<>(opt -> "filelists".equals(opt.getLongOpt()))
                 )
             )
         );

--- a/src/test/java/com/artipie/rpm/hm/NodeHasPkgCount.java
+++ b/src/test/java/com/artipie/rpm/hm/NodeHasPkgCount.java
@@ -9,6 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.hamcrest.core.IsEqual;
 import org.llorllale.cactoos.matchers.MatcherEnvelope;
+import org.llorllale.cactoos.matchers.MatcherOf;
 
 /**
  * Metadata has given amount of packages.
@@ -28,13 +29,15 @@ public final class NodeHasPkgCount extends MatcherEnvelope<XMLDocument> {
      */
     public NodeHasPkgCount(final int count, final String tag) {
         super(
-            xml -> new IsEqual<>(count).matches(countPackages(tag, xml))
-                && new IsEqual<>(count).matches(packagesAttributeValue(xml)),
-            desc -> desc.appendText(String.format("%d packages expected", count)),
-            (xml, desc) -> desc.appendText(
-                String.format(
-                    "%d packages found, 'packages' attribute value is %d",
-                    countPackages(tag, xml), packagesAttributeValue(xml)
+            new MatcherOf<>(
+                xml -> new IsEqual<>(count).matches(countPackages(tag, xml))
+                    && new IsEqual<>(count).matches(packagesAttributeValue(xml)),
+                desc -> desc.appendText(String.format("%d packages expected", count)),
+                (xml, desc) -> desc.appendText(
+                    String.format(
+                        "%d packages found, 'packages' attribute value is %d",
+                        countPackages(tag, xml), packagesAttributeValue(xml)
+                    )
                 )
             )
         );

--- a/src/test/java/com/artipie/rpm/hm/NodeHasPkgCountTest.java
+++ b/src/test/java/com/artipie/rpm/hm/NodeHasPkgCountTest.java
@@ -12,16 +12,12 @@ import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsNot;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.llorllale.cactoos.matchers.Matches;
 import org.llorllale.cactoos.matchers.Mismatches;
 
 /**
  * Test for {@link NodeHasPkgCount}.
  * @since 0.10
- * @todo #307:30min Test methods for description verification fail on windows: figure out why,
- *  fix it and remove disable annotation.
  * @checkstyle MagicNumberCheck (500 lines)
  */
 final class NodeHasPkgCountTest {
@@ -63,7 +59,6 @@ final class NodeHasPkgCountTest {
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS)
     void describesCorrectlyWhenPackagesAmountDiffers() throws FileNotFoundException {
         MatcherAssert.assertThat(
             new NodeHasPkgCount(10, XmlPackage.PRIMARY.tag()),
@@ -88,7 +83,6 @@ final class NodeHasPkgCountTest {
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS)
     void describesCorrectlyWhenPackageAttributeDiffers() throws FileNotFoundException {
         MatcherAssert.assertThat(
             new NodeHasPkgCount(2, XmlPackage.OTHER.tag()),

--- a/src/test/java/com/artipie/rpm/hm/StorageHasMetadata.java
+++ b/src/test/java/com/artipie/rpm/hm/StorageHasMetadata.java
@@ -14,7 +14,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.cactoos.text.FormattedText;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.llorllale.cactoos.matchers.MatcherOf;
@@ -52,9 +51,17 @@ public final class StorageHasMetadata extends AllOf<Storage> {
         final int expected, final boolean filelists, final Path temp
     ) {
         return new XmlPackage.Stream(filelists).get().map(
-            pckg -> new MatcherOf<Storage>(
-                storage -> hasMetadata(storage, temp, pckg, expected),
-                new FormattedText("Metadata %s has %d rpm packages", pckg.name(), expected)
+            pkg -> new MatcherOf<Storage>(
+                storage -> hasMetadata(storage, temp, pkg, expected),
+                desc -> desc.appendText(
+                    String.format("Metadata %s has %d rpm packages", pkg.name(), expected)
+                ),
+                (sto, desc) ->  desc.appendText(
+                    String.format(
+                        "%d rm packages found for metadata %s",
+                        expected, pkg.name()
+                    )
+                )
             )
         ).collect(Collectors.toList());
     }

--- a/src/test/java/com/artipie/rpm/hm/StorageHasRepoMd.java
+++ b/src/test/java/com/artipie/rpm/hm/StorageHasRepoMd.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import org.cactoos.text.FormattedText;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.llorllale.cactoos.matchers.MatcherOf;
@@ -55,16 +54,20 @@ public final class StorageHasRepoMd extends AllOf<Storage> {
     private static List<Matcher<? super Storage>> matchers(final RepoConfig config) {
         final List<Matcher<? super Storage>> res = new ArrayList<>(4);
         res.add(
-            new MatcherOf<Storage>(
+            new MatcherOf<>(
                 storage -> storage.exists(StorageHasRepoMd.REPOMD).join(),
-                new FormattedText("Repomd is present")
+                desc -> desc.appendText("Repomd is present"),
+                (sto, desc) ->  desc.appendText("Repomd is not present")
             )
         );
         new XmlPackage.Stream(config.filelists()).get().forEach(
-            pckg -> res.add(
-                new MatcherOf<Storage>(
-                    storage -> hasRecord(storage, pckg, config.digest()),
-                    new FormattedText("Repomd has record for %s xml", pckg.name())
+            pkg -> res.add(
+                new MatcherOf<>(
+                    storage -> hasRecord(storage, pkg, config.digest()),
+                    desc -> desc.appendText(
+                        String.format("Repomd has record for %s xml", pkg.name())
+                    ),
+                    (sto, desc) ->  String.format("Repomd has not record for %s xml", pkg.name())
                 )
             )
         );


### PR DESCRIPTION
We figured out that `Mismatches` (`cactoos-matchers:0.18`) failed to match on Windows
because line separator used in expected mismatch description contained
Unix separator while actual description contained windows separator.
So, we bumped `cactoos-matchers` to version `0.25` and updated all matchers impacted by
what's new in the new version.

Fix: #310