### PR TITLE
Write only greatest version of `libc.so` in primary

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlEventPrimary.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlEventPrimary.java
@@ -8,6 +8,7 @@ import com.artipie.rpm.misc.UncheckedConsumer;
 import com.artipie.rpm.pkg.HeaderTags;
 import com.artipie.rpm.pkg.Package;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -173,6 +174,7 @@ public final class XmlEventPrimary implements XmlEvent {
      * @param tags Tag info
      * @throws XMLStreamException On error
      */
+    @SuppressWarnings("PMD.CyclomaticComplexity")
     private static void addRequires(final XMLEventWriter writer, final HeaderTags tags)
         throws XMLStreamException {
         final XMLEventFactory events = XMLEventFactory.newFactory();
@@ -185,8 +187,13 @@ public final class XmlEventPrimary implements XmlEvent {
         final List<HeaderTags.Version> versions = tags.requiresVer();
         final Map<String, Integer> items = new HashMap<>(names.size());
         final Set<String> duplicates = new HashSet<>(names.size());
+        final List<String> libcso = new ArrayList<>(names.size());
         for (int ind = 0; ind < names.size(); ind = ind + 1) {
             final String name = names.get(ind);
+            if (name.startsWith("libc.so.")) {
+                libcso.add(name);
+                continue;
+            }
             int pre = 0;
             if ((intflags.get(ind)
                 & (XmlEventPrimary.RPMSENSE_PREREQ
@@ -219,6 +226,16 @@ public final class XmlEventPrimary implements XmlEvent {
                 );
             }
             duplicates.add(full);
+        }
+        if (!libcso.isEmpty()) {
+            libcso.sort(new CrCompareDependency());
+            writer.add(
+                events.createStartElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "entry")
+            );
+            writer.add(events.createAttribute("name", libcso.get(libcso.size() - 1)));
+            writer.add(
+                events.createEndElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "entry")
+            );
         }
         writer.add(
             events.createEndElement(XmlEventPrimary.PRFX, XmlEventPrimary.NS_URL, "requires")

--- a/src/test/resources-binary/AstoMetadataAddTest/primary-res.xml
+++ b/src/test/resources-binary/AstoMetadataAddTest/primary-res.xml
@@ -90,10 +90,9 @@
                 <rpm:entry name="/sbin/ldconfig" pre="1"/>
                 <rpm:entry name="ld-linux-armhf.so.3"/>
                 <rpm:entry name="ld-linux-armhf.so.3(GLIBC_2.4)"/>
-                <rpm:entry name="libc.so.6"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.4)"/>
                 <rpm:entry name="libgcc_s.so.1"/>
                 <rpm:entry name="libgcc_s.so.1(GCC_3.5)"/>
+                <rpm:entry name="libc.so.6(GLIBC_2.4)"/>
             </rpm:requires>
         </format>
     </package>
@@ -135,9 +134,8 @@
             <rpm:requires>
                 <rpm:entry name="abc-libs(ppc-64)" flags="EQ" ver="1.01" epoch="0" rel="26.git20200127.fc32"/>
                 <rpm:entry name="libabc.so.0()(64bit)"/>
-                <rpm:entry name="libc.so.6()(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.17)(64bit)"/>
                 <rpm:entry name="rtld(GNU_HASH)"/>
+                <rpm:entry name="libc.so.6(GLIBC_2.17)(64bit)"/>
             </rpm:requires>
             <file>/usr/bin/abc</file>
         </format>

--- a/src/test/resources-binary/XmlEventPrimaryTest/abc_res.xml
+++ b/src/test/resources-binary/XmlEventPrimaryTest/abc_res.xml
@@ -41,9 +41,8 @@
             <rpm:requires>
                 <rpm:entry name="abc-libs(ppc-64)" flags="EQ" ver="1.01" epoch="0" rel="26.git20200127.fc32"/>
                 <rpm:entry name="libabc.so.0()(64bit)"/>
-                <rpm:entry name="libc.so.6()(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.17)(64bit)"/>
                 <rpm:entry name="rtld(GNU_HASH)"/>
+                <rpm:entry name="libc.so.6(GLIBC_2.17)(64bit)"/>
             </rpm:requires>
             <file>/usr/bin/abc</file>
         </format>

--- a/src/test/resources-binary/XmlEventPrimaryTest/httpd_res.xml
+++ b/src/test/resources-binary/XmlEventPrimaryTest/httpd_res.xml
@@ -44,12 +44,6 @@
                 <rpm:entry name="/bin/sh" pre="1"/>
                 <rpm:entry name="libapr-1.so.0()(64bit)"/>
                 <rpm:entry name="libaprutil-1.so.0()(64bit)"/>
-                <rpm:entry name="libc.so.6()(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.14)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.2.5)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.3)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.3.4)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.4)(64bit)"/>
                 <rpm:entry name="libcrypt.so.1()(64bit)"/>
                 <rpm:entry name="libdb-5.3.so()(64bit)"/>
                 <rpm:entry name="libdl.so.2()(64bit)"/>
@@ -64,6 +58,7 @@
                 <rpm:entry name="libsystemd-daemon.so.0(LIBSYSTEMD_DAEMON_31)(64bit)"/>
                 <rpm:entry name="libz.so.1()(64bit)"/>
                 <rpm:entry name="rtld(GNU_HASH)"/>
+                <rpm:entry name="libc.so.6(GLIBC_2.14)(64bit)"/>
             </rpm:requires>
             <file type="dir">/etc/httpd</file>
             <file type="dir">/etc/httpd/conf</file>

--- a/src/test/resources-binary/XmlEventPrimaryTest/openssh_res.xml
+++ b/src/test/resources-binary/XmlEventPrimaryTest/openssh_res.xml
@@ -33,15 +33,6 @@
                 <rpm:entry name="/usr/sbin/useradd" pre="1"/>
                 <rpm:entry name="fipscheck-lib(x86-64)" flags="GE" ver="1.3.0" epoch="0"/>
                 <rpm:entry name="libaudit.so.1()(64bit)"/>
-                <rpm:entry name="libc.so.6()(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.14)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.16)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.17)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.2.5)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.3)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.3.4)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.4)(64bit)"/>
-                <rpm:entry name="libc.so.6(GLIBC_2.8)(64bit)"/>
                 <rpm:entry name="libcom_err.so.2()(64bit)"/>
                 <rpm:entry name="libcrypt.so.1()(64bit)"/>
                 <rpm:entry name="libcrypt.so.1(GLIBC_2.2.5)(64bit)"/>
@@ -72,6 +63,7 @@
                 <rpm:entry name="pam" flags="GE" ver="1.0.1" epoch="0" rel="3"/>
                 <rpm:entry name="rtld(GNU_HASH)"/>
                 <rpm:entry name="systemd-units" pre="1"/>
+                <rpm:entry name="libc.so.6(GLIBC_2.17)(64bit)"/>
             </rpm:requires>
             <file>/etc/pam.d/sshd</file>
             <file>/etc/ssh/sshd_config</file>


### PR DESCRIPTION
Part of #489 
Added `libc.so` versions comparison, now only greatest version is written to primary.xml.