### PR TITLE
feat(XmlEvent) : check if primary file is a ghost

### DIFF
--- a/src/main/java/com/artipie/rpm/meta/XmlEvent.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlEvent.java
@@ -109,6 +109,7 @@ public interface XmlEvent {
      * @see <a href="https://man7.org/linux/man-pages/man7/inode.7.html">Man page for file inode information</a>
      * @see <a href="https://github.com/rpm-software-management/createrepo_c/blob/b49b8b2586c07d3e84009beba677162b86539f9d/src/parsehdr.c#L256">Create repo implementation</a>
      * @since 1.5
+     * @checkstyle ExecutableStatementCountCheck (300 lines)
      */
     @SuppressWarnings("PMD.AvoidUsingOctalValues")
     final class Files implements XmlEvent {

--- a/src/main/java/com/artipie/rpm/meta/XmlEvent.java
+++ b/src/main/java/com/artipie/rpm/meta/XmlEvent.java
@@ -12,6 +12,7 @@ import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
+import org.redline_rpm.payload.Directive;
 
 /**
  * Xml event to write to the output stream.
@@ -153,6 +154,7 @@ public interface XmlEvent {
                 final String[] dirs = tags.dirNames().toArray(new String[0]);
                 final int[] did = tags.dirIndexes();
                 final int[] fmod = tags.fileModes();
+                final int[] flags = tags.fileFlags();
                 for (int idx = 0; idx < files.length; idx += 1) {
                     final String fle = files[idx];
                     // @checkstyle MethodBodyCommentsCheck (2 lines)
@@ -166,14 +168,10 @@ public interface XmlEvent {
                         continue;
                     }
                     writer.add(events.createStartElement("", "", "file"));
-                    // @checkstyle MethodBodyCommentsCheck (5 lines)
-                    // @todo #501:30min Analyze condition by which we add `ghost`.
-                    //  We need to get file flag number and compare it to `rpmfile_ghost` mode by
-                    //  `&` operator. Obviously, when a file isn't a `directory` or a `ghost`,
-                    //  it is a `regular file (empty type). These changes will break some tests
-                    //  which will therefore have to be fixed.
                     if ((fmod[idx] & Files.S_IFMT) == Files.S_IFDIR) {
                         writer.add(events.createAttribute("type", "dir"));
+                    } else if ((flags[idx] & Directive.RPMFILE_GHOST) > 0) {
+                        writer.add(events.createAttribute("type", "ghost"));
                     }
                     writer.add(events.createCharacters(path));
                     writer.add(events.createEndElement("", "", "file"));

--- a/src/main/java/com/artipie/rpm/pkg/HeaderTags.java
+++ b/src/main/java/com/artipie/rpm/pkg/HeaderTags.java
@@ -330,6 +330,14 @@ public final class HeaderTags {
     }
 
     /**
+     * Get the file flags header.
+     * @return Value of header tag FILEFLAGS.
+     */
+    public int[] fileFlags() {
+        return this.meta.header(Header.HeaderTag.FILEFLAGS).asInts();
+    }
+
+    /**
      * Get the changelog header.
      * @return Value of header tag CHANGELOG.
      */

--- a/src/test/java/com/artipie/rpm/pkg/HeaderTagsTest.java
+++ b/src/test/java/com/artipie/rpm/pkg/HeaderTagsTest.java
@@ -102,4 +102,14 @@ class HeaderTagsTest {
         );
     }
 
+    @Test
+    void readsFileFlags() throws IOException {
+        final Path file = new TestResource("time-1.7-45.el7.x86_64.rpm").asPath();
+        MatcherAssert.assertThat(
+            new HeaderTags(
+                new FilePackage.Headers(new FilePackageHeader(file).header(), file, Digest.SHA256)
+            ).fileFlags(),
+            new IsEqual<>(new int[] {0, 0, 2, 2, 2, 2, 2, 2})
+        );
+    }
 }

--- a/src/test/resources-binary/XmlEventPrimaryTest/authconfig_res.xml
+++ b/src/test/resources-binary/XmlEventPrimaryTest/authconfig_res.xml
@@ -55,11 +55,11 @@
                 <rpm:entry name="freeipa-client" ver="2.2.0" epoch="0" flags="LT"/>
                 <rpm:entry name="ipa-client" ver="2.2.0" epoch="0" flags="LT"/>
             </rpm:conflicts>
-            <file>/etc/pam.d/fingerprint-auth-ac</file>
-            <file>/etc/pam.d/password-auth-ac</file>
-            <file>/etc/pam.d/postlogin-ac</file>
-            <file>/etc/pam.d/smartcard-auth-ac</file>
-            <file>/etc/pam.d/system-auth-ac</file>
+            <file type="ghost">/etc/pam.d/fingerprint-auth-ac</file>
+            <file type="ghost">/etc/pam.d/password-auth-ac</file>
+            <file type="ghost">/etc/pam.d/postlogin-ac</file>
+            <file type="ghost">/etc/pam.d/smartcard-auth-ac</file>
+            <file type="ghost">/etc/pam.d/system-auth-ac</file>
             <file>/etc/sysconfig/authconfig</file>
             <file>/usr/sbin/authconfig</file>
             <file>/usr/sbin/authconfig-tui</file>


### PR DESCRIPTION
We check now if a file is a `ghost` exactly as it's done in `createrepo` and we add `type=ghost` to its entity if it's true.
As expected, these new changes broke some tests. We fixed them all.

Resolve: #512