### PR TITLE
feat: use new permissions model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>v1.1.4</version>
+      <version>v1.2.3</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -111,7 +111,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto-core</artifactId>
-      <version>v1.15.0</version>
+      <version>v1.15.4</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/com/artipie/rpm/CliArguments.java
+++ b/src/main/java/com/artipie/rpm/CliArguments.java
@@ -157,5 +157,10 @@ public final class CliArguments {
                 this.cli.getOptionValue(RpmOptions.UPDATE.option().getOpt())
             );
         }
+
+        @Override
+        public String name() {
+            throw new UnsupportedOperationException("Method name() is not supported");
+        }
     }
 }

--- a/src/main/java/com/artipie/rpm/RepoConfig.java
+++ b/src/main/java/com/artipie/rpm/RepoConfig.java
@@ -51,6 +51,12 @@ public interface RepoConfig {
     Optional<String> cron();
 
     /**
+     * Repository name.
+     * @return String name
+     */
+    String name();
+
+    /**
      * Rpm repository update mode.
      * @since 1.9
      */
@@ -90,19 +96,27 @@ public interface RepoConfig {
         private final YamlMapping yaml;
 
         /**
+         * Repository name.
+         */
+        private final String name;
+
+        /**
          * Ctor.
          * @param yaml Yaml settings
+         * @param name Repository name
          */
-        public FromYaml(final YamlMapping yaml) {
+        public FromYaml(final YamlMapping yaml, final String name) {
             this.yaml = yaml;
+            this.name = name;
         }
 
         /**
          * Ctor.
          * @param yaml Yaml settings
+         * @param name Repository name
          */
-        public FromYaml(final Optional<YamlMapping> yaml) {
-            this(yaml.orElse(Yaml.createYamlMappingBuilder().build()));
+        public FromYaml(final Optional<YamlMapping> yaml, final String name) {
+            this(yaml.orElse(Yaml.createYamlMappingBuilder().build()), name);
         }
 
         @Override
@@ -155,6 +169,11 @@ public interface RepoConfig {
                 );
             }
             return res;
+        }
+
+        @Override
+        public String name() {
+            return this.name;
         }
     }
 
@@ -248,6 +267,11 @@ public interface RepoConfig {
         @Override
         public Optional<String> cron() {
             return Optional.empty();
+        }
+
+        @Override
+        public String name() {
+            return "test";
         }
     }
 }


### PR DESCRIPTION
closes #545 

As rpm repository has it's own extended repo config, I've added a method for repository name.