### PR TITLE
Updated org.bouncycastle:bcpg-jdk15on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,17 @@ SOFTWARE.
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-compress</artifactId>
         </exclusion>
+        <!-- org.bouncycastle:bcpg-jdk15on:1.69 is excluded because of some vulnerabilities, version 1.70 is used -->
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpg-jdk15on</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpg-jdk15on</artifactId>
+      <version>1.70</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Updated `org.bouncycastle:bcpg-jdk15on` version by request from Chinese colleagues. We use latest version of `org.redline-rpm`, so I've excluded and older version of `org.bouncycastle:bcpg-jdk15on` and added the latest.